### PR TITLE
fix: self-sign identity for apple security

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
       "exceptionDomain": "",
       "frameworks": [],
       "providerShortName": null,
-      "signingIdentity": null,
+      "signingIdentity": "-",
       "dmg": {
         "background": "dmg-background.png",
         "windowSize": {


### PR DESCRIPTION
The application fails to open on MacOS saying the application is damaged. This is a apple security signing setting that can be resolved by running the below command.

```
xattr -c /Applications/DevPod.app
```

https://github.com/tauri-apps/tauri-action/issues/866
Signed-off-by: Samuel K <69881238+skevetter@users.noreply.github.com>
