### PR TITLE
fix: Use target architecture for image inspection in non-Docker drivers

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/loft-sh/log"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -106,4 +107,21 @@ func IsValidDockerTag(tag string) bool {
 
 func shouldNotBeSlugged(data string, regexp *regexp.Regexp, maxSize int) bool {
 	return len(data) == 0 || regexp.Match([]byte(data)) && len(data) <= maxSize
+}
+
+func GetImageConfigForArch(ctx context.Context, image, arch string, log log.Logger) (*v1.ConfigFile, v1.Image, error) {
+	log.Debugf("Getting image config for image '%s' with architecture '%s'", image, arch)
+	defer log.Debugf("Done getting image config for image '%s' with architecture '%s'", image, arch)
+
+	img, err := GetImageForArch(ctx, image, arch)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	configFile, err := img.ConfigFile()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "config file")
+	}
+
+	return configFile, img, nil
 }


### PR DESCRIPTION
When using non-Docker drivers (like Kubernetes), the inspectImage function was falling back to GetImageConfig which defaults to linux/amd64 architecture. This caused architecture mismatches when the target platform was different.

Changes:
- Added GetImageConfigForArch function to image package
- Modified inspectImage to retrieve target architecture from driver
- Updated inspectImage to use architecture-specific image config retrieval
- Added proper error handling with descriptive messages

Fixes architecture detection for Kubernetes and other non-Docker drivers.