### PR TITLE
fix(copy): resolve user lookup by name or integer

### DIFF
--- a/e2e/tests/up/docker.go
+++ b/e2e/tests/up/docker.go
@@ -85,6 +85,11 @@ var _ = DevPodDescribe("devpod up test suite", func() {
 				err = dtc.f.DevPodUp(ctx, tempDir, "--source", fmt.Sprintf("container:%s", containerDetails[0].ID))
 				framework.ExpectNoError(err)
 			}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
+			ginkgo.It("user lookup with no remoteUser", func(ctx context.Context) {
+				_, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-compose-lookup-user")
+				framework.ExpectNoError(err)
+			}, ginkgo.SpecTimeout(framework.GetTimeout()))
 		})
 
 		ginkgo.Context("devcontainer configuration", func() {

--- a/e2e/tests/up/testdata/docker-compose-lookup-user/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-compose-lookup-user/.devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Node.js",
+  "image": "docker.io/library/node:lts-alpine"
+}


### PR DESCRIPTION
References issue https://github.com/skevetter/devpod/issues/143

Some images like `docker.io/library/node:lts-alpine` do not have a user name but has a user in uid:gid format (e.g., 1000:1000). Adds functionality to parse integer uid.

Signed-off-by: Samuel K <69881238+skevetter@users.noreply.github.com>
