### PR TITLE
Larger page for provider repositories request.

### DIFF
--- a/cmd/provider/list-default-providers.go
+++ b/cmd/provider/list-default-providers.go
@@ -19,7 +19,7 @@ type ListAvailableCmd struct {
 }
 
 func getDevpodProviderList() error {
-	req, err := http.NewRequest("GET", "https://api.github.com/users/loft-sh/repos", nil)
+	req, err := http.NewRequest("GET", "https://api.github.com/users/loft-sh/repos?per_page=100", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently, output of `devpod provider list-available` is awfully short: just 'aws' and 'azure'; I increased page size on the GitHub API request that retrieves the list of the `loft-sh` repositories from its default 30 to its maximum 100, and now all the providers residing in dedicated repositories seem to be listed (including the ones missing from the list in the official documentation https://devpod.sh/docs/managing-providers/add-provider). Coding a proper paged query is beyond me; besides, maybe at some point we will switch to listing providers from this fork ;)