### PR TITLE
feat(ide/jetbrains): suppress JetBrains trust dialog

### DIFF
--- a/cmd/pro/provider/create/workspace.go
+++ b/cmd/pro/provider/create/workspace.go
@@ -52,7 +52,7 @@ func (cmd *WorkspaceCmd) Run(ctx context.Context, stdin io.Reader, stdout io.Wri
 		return err
 	}
 
-	// fully serialized intance, right now only used by GUI
+	// fully serialized instance, right now only used by GUI
 	instanceEnv := os.Getenv(platform.WorkspaceInstanceEnv)
 	if instanceEnv != "" {
 		instance := &managementv1.DevPodWorkspaceInstance{} // init pointer

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -28,9 +28,9 @@ type AddCmd struct {
 }
 
 // NewAddCmd creates a new command
-func NewAddCmd(flags *flags.GlobalFlags) *cobra.Command {
+func NewAddCmd(f *flags.GlobalFlags) *cobra.Command {
 	cmd := &AddCmd{
-		GlobalFlags: flags,
+		GlobalFlags: f,
 	}
 	addCmd := &cobra.Command{
 		Use:   "add [URL or path]",
@@ -52,7 +52,7 @@ func NewAddCmd(flags *flags.GlobalFlags) *cobra.Command {
 		},
 	}
 
-	addCmd.Flags().BoolVar(&cmd.SingleMachine, "single-machine", false, "If enabled will use a single machine for all workspaces")
+	flags.BoolVarE(addCmd.Flags(), &cmd.SingleMachine, "single-machine", flags.DevpodEnvPrefix+"SINGLE_MACHINE", false, "If enabled will use a single machine for all workspaces")
 	addCmd.Flags().StringVar(&cmd.Name, "name", "", "The name to use for this provider. If empty will use the name within the loaded config")
 	addCmd.Flags().StringVar(&cmd.FromExisting, "from-existing", "", "The name of an existing provider to use as a template. Needs to be used in conjunction with the --name flag")
 	addCmd.Flags().BoolVar(&cmd.Use, "use", true, "If enabled will automatically activate the provider")

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -54,7 +54,7 @@ func NewUseCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func AddFlags(useCmd *cobra.Command, cmd *UseCmd) {
-	useCmd.Flags().BoolVar(&cmd.SingleMachine, "single-machine", false, "If enabled will use a single machine for all workspaces")
+	flags.BoolVarE(useCmd.Flags(), &cmd.SingleMachine, "single-machine", flags.DevpodEnvPrefix+"SINGLE_MACHINE", false, "If enabled will use a single machine for all workspaces")
 	useCmd.Flags().BoolVar(&cmd.Reconfigure, "reconfigure", false, "If enabled will not merge existing provider config")
 	useCmd.Flags().StringArrayVarP(&cmd.Options, "option", "o", []string{}, "Provider option in the form KEY=VALUE")
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -131,7 +131,7 @@ func NewUpCmd(f *flags.GlobalFlags) *cobra.Command {
 	upCmd.Flags().BoolVar(&cmd.Recreate, "recreate", false, "If true will remove any existing containers and recreate them")
 	upCmd.Flags().BoolVar(&cmd.Reset, "reset", false, "If true will remove any existing containers including sources, and recreate them")
 	upCmd.Flags().StringSliceVar(&cmd.PrebuildRepositories, "prebuild-repository", []string{}, "Docker repository that hosts devpod prebuilds for this workspace")
-	upCmd.Flags().StringArrayVar(&cmd.WorkspaceEnv, "workspace-env", []string{}, "Extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
+	flags.StringArrayVarE(upCmd.Flags(), &cmd.WorkspaceEnv, "workspace-env", flags.DevpodEnvPrefix+"WORKSPACE_ENV", []string{}, "Extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
 	upCmd.Flags().StringSliceVar(&cmd.WorkspaceEnvFile, "workspace-env-file", []string{}, "The path to files containing a list of extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
 	upCmd.Flags().StringArrayVar(&cmd.InitEnv, "init-env", []string{}, "Extra env variables to inject during the initialization of the workspace. E.g. MY_ENV_VAR=MY_VALUE")
 	upCmd.Flags().StringVar(&cmd.ID, "id", "", "The id to use for the workspace")

--- a/pkg/ide/types.go
+++ b/pkg/ide/types.go
@@ -47,7 +47,14 @@ func (o Options) GetValue(values map[string]config.OptionValue, key string) stri
 // ReusesAuthSock determines if the --reuse-ssh-auth-sock flag should be passed to the ssh server helper based on the IDE.
 // Browser based IDEs use a browser tunnel to communicate with the remote server instead of an independent ssh connection
 func ReusesAuthSock(ide string) bool {
-	return ide == "openvscode" || ide == "jupyternotebook"
+	switch ide {
+	case string(config.IDEOpenVSCode):
+		return true
+	case string(config.IDEJupyterNotebook):
+		return true
+	default:
+		return false
+	}
 }
 
 type ProgressReader struct {


### PR DESCRIPTION
When a workspace is opened for the first time in a JetBrains IDE, a trust dialog pops up.

In most cases, is useless and annoying.

Fortunately, JetBrains provide a way to suppress this dialog: set a workspace environment variable `REMOTE_DEV_TRUST_PROJECTS` to any value.

Unfortunately, supplying `--workspace-env REMOTE_DEV_TRUST_PROJECTS=1`
to `devpod up` explicitly on the `devpod up` command line is arguably even more annoying...

This pull request adds a few more environment variables that can be used to supply values for devpod CLI options.

One of them can be used to seamlessly suppresses JetBrains trust dialog:

set `DEVPOD_WORKSPACE_ENV="REMOTE_DEV_TRUST_PROJECTS=1"` - for instance, in `.envrc` file.
