### PR TITLE
feat(cli/environment): use environment variables to set all flags not supplied explicitly

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -1,13 +1,7 @@
 package flags
 
 import (
-	"encoding/csv"
-	"os"
-	"strconv"
-	"strings"
-
 	"github.com/skevetter/devpod/pkg/platform"
-	"github.com/skevetter/log"
 	flag "github.com/spf13/pflag"
 )
 
@@ -24,80 +18,16 @@ type GlobalFlags struct {
 	Silent    bool
 }
 
-const DevpodEnvPrefix = "DEVPOD_"
-
-// Defines a string flag with specified name, environment variable, default value, and usage string.
-// The argument variable points to a string variable in which to store the value of the flag.
-func StringVarE(f *flag.FlagSet, variable *string, name string, environmentVariable string, defaultValue string, usage string) {
-	f.StringVar(variable, name, GetStringEnv(environmentVariable, defaultValue), usage+". You can also use "+environmentVariable+" to set this")
-}
-
-func GetStringEnv(environmentVariable string, defaultValue string) string {
-	if value, exists := os.LookupEnv(environmentVariable); exists {
-		return value
-	}
-	return defaultValue
-}
-
-// Defines a bool flag with specified name, environment variable, default value, and usage string.
-// The argument variable points to a bool variable in which to store the value of the flag.
-func BoolVarE(f *flag.FlagSet, variable *bool, name string, environmentVariable string, defaultValue bool, usage string) {
-	f.BoolVar(variable, name, GetBoolEnv(environmentVariable, defaultValue), usage+". You can also use "+environmentVariable+" to set this")
-}
-
-func GetBoolEnv(environmentVariable string, defaultValue bool) bool {
-	if value, exists := os.LookupEnv(environmentVariable); exists {
-		result, err := strconv.ParseBool(value)
-		if err != nil {
-			log.Default.Warnf("invalid boolean value %s for environment variable %s, falling back to default %v", value, environmentVariable, defaultValue)
-			return defaultValue
-		}
-		return result
-	}
-	return defaultValue
-}
-
-// Defines a string flag with specified name, environment variable, default value, and usage string.
-// The argument variable points to a []string variable in which to store the values of the multiple flags.
-// The value of each argument will not try to be separated by comma. Use a StringSliceVar for that.
-func StringArrayVarE(f *flag.FlagSet, variable *[]string, name string, environmentVariable string, defaultValue []string, usage string) {
-	f.StringArrayVar(variable, name, GetStringSliceEnv(environmentVariable, defaultValue), usage)
-}
-
-// Defines a string flag with specified name, environment variable, default value, and usage string.
-// The argument variable points to a []string variable in which to store the value of the flag.
-// Compared to StringArrayVar flags, StringSliceVar flags take comma-separated value as arguments and split them accordingly.
-func StringSliceVarE(f *flag.FlagSet, variable *[]string, name string, environmentVariable string, defaultValue []string, usage string) {
-	f.StringSliceVar(variable, name, GetStringSliceEnv(environmentVariable, defaultValue), usage)
-}
-
-func GetStringSliceEnv(environmentVariable string, defaultValue []string) []string {
-	if value, exists := os.LookupEnv(environmentVariable); exists {
-		if value == "" {
-			return []string{}
-		}
-		stringReader := strings.NewReader(value)
-		csvReader := csv.NewReader(stringReader)
-		result, err := csvReader.Read()
-		if err != nil {
-			log.Default.Warnf("invalid string list value %s for environment variable %s, falling back to default %v", value, environmentVariable, defaultValue)
-			return defaultValue
-		}
-		return result
-	}
-	return defaultValue
-}
-
 // SetGlobalFlags applies the global flags
 func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	globalFlags := &GlobalFlags{}
 
-	flags.StringVar(&globalFlags.DevPodHome, "devpod-home", "", "If defined will override the default devpod home. You can also use DEVPOD_HOME to set this")
-	StringVarE(flags, &globalFlags.LogOutput, "log-output", DevpodEnvPrefix+"LOG_OUTPUT", "plain", "The log format to use. Can be either plain, raw or json")
-	StringVarE(flags, &globalFlags.Context, "context", DevpodEnvPrefix+"CONTEXT", "", "The context to use")
-	StringVarE(flags, &globalFlags.Provider, "provider", DevpodEnvPrefix+"PROVIDER", "", "The provider to use. Needs to be configured for the selected context")
-	BoolVarE(flags, &globalFlags.Debug, "debug", DevpodEnvPrefix+"DEBUG", false, "Prints the stack trace if an error occurs")
-	BoolVarE(flags, &globalFlags.Silent, "silent", DevpodEnvPrefix+"SILENT", false, "Run in silent mode and prevents any devpod log output except panics & fatals")
+	flags.StringVar(&globalFlags.DevPodHome, "devpod-home", "", "If defined will override the default devpod home")
+	flags.StringVar(&globalFlags.LogOutput, "log-output", "plain", "The log format to use. Can be either plain, raw or json")
+	flags.StringVar(&globalFlags.Context, "context", "", "The context to use")
+	flags.StringVar(&globalFlags.Provider, "provider", "", "The provider to use. Needs to be configured for the selected context")
+	flags.BoolVar(&globalFlags.Debug, "debug", false, "Prints the stack trace if an error occurs")
+	flags.BoolVar(&globalFlags.Silent, "silent", false, "Run in silent mode and prevents any devpod log output except panics & fatals")
 
 	flags.Var(&globalFlags.Owner, "owner", "Show pro workspaces for owner")
 	_ = flags.MarkHidden("owner")

--- a/cmd/ide/use.go
+++ b/cmd/ide/use.go
@@ -76,10 +76,10 @@ func (cmd *UseCmd) Run(ctx context.Context, ide string) error {
 }
 
 func setOptions(devPodConfig *config.Config, ide string, userOptions []string, ideOptions ide.Options) error {
-	userOptions = options2.PropagateOptionsFromEnvironment(
+	userOptions = options2.InheritOptionsFromEnvironment(
 		userOptions,
 		ideOptions,
-		flags.DevpodEnvPrefix+"IDE_"+ide+"_",
+		"DEVPOD_IDE_"+ide+"_",
 	)
 
 	optionValues, err := ideparse.ParseOptions(userOptions, ideOptions)

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -52,7 +52,7 @@ func NewAddCmd(f *flags.GlobalFlags) *cobra.Command {
 		},
 	}
 
-	flags.BoolVarE(addCmd.Flags(), &cmd.SingleMachine, "single-machine", flags.DevpodEnvPrefix+"SINGLE_MACHINE", false, "If enabled will use a single machine for all workspaces")
+	addCmd.Flags().BoolVar(&cmd.SingleMachine, "single-machine", false, "If enabled will use a single machine for all workspaces")
 	addCmd.Flags().StringVar(&cmd.Name, "name", "", "The name to use for this provider. If empty will use the name within the loaded config")
 	addCmd.Flags().StringVar(&cmd.FromExisting, "from-existing", "", "The name of an existing provider to use as a template. Needs to be used in conjunction with the --name flag")
 	addCmd.Flags().BoolVar(&cmd.Use, "use", true, "If enabled will automatically activate the provider")

--- a/cmd/provider/set_options.go
+++ b/cmd/provider/set_options.go
@@ -46,7 +46,7 @@ func NewSetOptionsCmd(f *flags.GlobalFlags) *cobra.Command {
 		},
 	}
 
-	flags.BoolVarE(setOptionsCmd.Flags(), &cmd.SingleMachine, "single-machine", flags.DevpodEnvPrefix+"SINGLE_MACHINE", false, "If enabled will use a single machine for all workspaces")
+	setOptionsCmd.Flags().BoolVar(&cmd.SingleMachine, "single-machine", false, "If enabled will use a single machine for all workspaces")
 	setOptionsCmd.Flags().BoolVar(&cmd.Reconfigure, "reconfigure", false, "If enabled will not merge existing provider config")
 	setOptionsCmd.Flags().StringArrayVarP(&cmd.Options, "option", "o", []string{}, "Provider option in the form KEY=VALUE")
 	setOptionsCmd.Flags().BoolVar(&cmd.Dry, "dry", false, "Dry will not persist the options to file and instead return the new filled options")

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -54,7 +54,7 @@ func NewUseCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func AddFlags(useCmd *cobra.Command, cmd *UseCmd) {
-	flags.BoolVarE(useCmd.Flags(), &cmd.SingleMachine, "single-machine", flags.DevpodEnvPrefix+"SINGLE_MACHINE", false, "If enabled will use a single machine for all workspaces")
+	useCmd.Flags().BoolVar(&cmd.SingleMachine, "single-machine", false, "If enabled will use a single machine for all workspaces")
 	useCmd.Flags().BoolVar(&cmd.Reconfigure, "reconfigure", false, "If enabled will not merge existing provider config")
 	useCmd.Flags().StringArrayVarP(&cmd.Options, "option", "o", []string{}, "Provider option in the form KEY=VALUE")
 
@@ -139,10 +139,10 @@ func setOptions(
 		return nil, err
 	}
 
-	userOptions = options2.PropagateOptionsFromEnvironment(
+	userOptions = options2.InheritOptionsFromEnvironment(
 		userOptions,
 		provider.Options,
-		flags.DevpodEnvPrefix+"PROVIDER_"+provider.Name+"_",
+		"DEVPOD_PROVIDER_"+provider.Name+"_",
 	)
 
 	// parse options

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -115,13 +115,13 @@ func NewUpCmd(f *flags.GlobalFlags) *cobra.Command {
 			return cmd.Run(ctx, devPodConfig, client, args, logger)
 		},
 	}
-	flags.BoolVarE(upCmd.Flags(), &cmd.ConfigureSSH, "configure-ssh", flags.DevpodEnvPrefix+"CONFIGURE_SSH", true, "If true will configure the ssh config to include the DevPod workspace")
-	flags.BoolVarE(upCmd.Flags(), &cmd.GPGAgentForwarding, "gpg-agent-forwarding", flags.DevpodEnvPrefix+"GPG_AGENT_FORWARDING", false, "If true forward the local gpg-agent to the DevPod workspace")
-	flags.StringVarE(upCmd.Flags(), &cmd.SSHConfigPath, "ssh-config", flags.DevpodEnvPrefix+"SSH_CONFIG", "", "The path to the ssh config to modify, if empty will use ~/.ssh/config")
-	flags.StringVarE(upCmd.Flags(), &cmd.DotfilesSource, "dotfiles", flags.DevpodEnvPrefix+"DOTFILES", "", "The path or url to the dotfiles to use in the container")
-	flags.StringVarE(upCmd.Flags(), &cmd.DotfilesScript, "dotfiles-script", flags.DevpodEnvPrefix+"DOTFILES_SCRIPT", "", "The path in dotfiles directory to use to install the dotfiles, if empty will try to guess")
-	flags.StringSliceVarE(upCmd.Flags(), &cmd.DotfilesScriptEnv, "dotfiles-script-env", flags.DevpodEnvPrefix+"DOTFILES_SCRIPT_ENV", []string{}, "Extra environment variables to put into the dotfiles install script. E.g. MY_ENV_VAR=MY_VALUE")
-	flags.StringSliceVarE(upCmd.Flags(), &cmd.DotfilesScriptEnvFile, "dotfiles-script-env-file", flags.DevpodEnvPrefix+"DOTFILES_SCRIPT_ENV_FILE", []string{}, "The path to files containing environment variables to set for the dotfiles install script")
+	upCmd.Flags().BoolVar(&cmd.ConfigureSSH, "configure-ssh", true, "If true will configure the ssh config to include the DevPod workspace")
+	upCmd.Flags().BoolVar(&cmd.GPGAgentForwarding, "gpg-agent-forwarding", false, "If true forward the local gpg-agent to the DevPod workspace")
+	upCmd.Flags().StringVar(&cmd.SSHConfigPath, "ssh-config", "", "The path to the ssh config to modify, if empty will use ~/.ssh/config")
+	upCmd.Flags().StringVar(&cmd.DotfilesSource, "dotfiles", "", "The path or url to the dotfiles to use in the container")
+	upCmd.Flags().StringVar(&cmd.DotfilesScript, "dotfiles-script", "", "The path in dotfiles directory to use to install the dotfiles, if empty will try to guess")
+	upCmd.Flags().StringSliceVar(&cmd.DotfilesScriptEnv, "dotfiles-script-env", []string{}, "Extra environment variables to put into the dotfiles install script. E.g. MY_ENV_VAR=MY_VALUE")
+	upCmd.Flags().StringSliceVar(&cmd.DotfilesScriptEnvFile, "dotfiles-script-env-file", []string{}, "The path to files containing environment variables to set for the dotfiles install script")
 	upCmd.Flags().StringArrayVar(&cmd.IDEOptions, "ide-option", []string{}, "IDE option in the form KEY=VALUE")
 	upCmd.Flags().StringVar(&cmd.DevContainerImage, "devcontainer-image", "", "The container image to use, this will override the devcontainer.json value in the project")
 	upCmd.Flags().StringVar(&cmd.DevContainerPath, "devcontainer-path", "", "The path to the devcontainer.json relative to the project")
@@ -132,17 +132,17 @@ func NewUpCmd(f *flags.GlobalFlags) *cobra.Command {
 	upCmd.Flags().BoolVar(&cmd.Recreate, "recreate", false, "If true will remove any existing containers and recreate them")
 	upCmd.Flags().BoolVar(&cmd.Reset, "reset", false, "If true will remove any existing containers including sources, and recreate them")
 	upCmd.Flags().StringSliceVar(&cmd.PrebuildRepositories, "prebuild-repository", []string{}, "Docker repository that hosts devpod prebuilds for this workspace")
-	flags.StringArrayVarE(upCmd.Flags(), &cmd.WorkspaceEnv, "workspace-env", flags.DevpodEnvPrefix+"WORKSPACE_ENV", []string{}, "Extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
-	flags.StringSliceVarE(upCmd.Flags(), &cmd.WorkspaceEnvFile, "workspace-env-file", flags.DevpodEnvPrefix+"WORKSPACE_ENV_FILE", []string{}, "The path to files containing a list of extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
-	flags.StringArrayVarE(upCmd.Flags(), &cmd.InitEnv, "init-env", flags.DevpodEnvPrefix+"INIT_ENV", []string{}, "Extra env variables to inject during the initialization of the workspace. E.g. MY_ENV_VAR=MY_VALUE")
+	upCmd.Flags().StringArrayVar(&cmd.WorkspaceEnv, "workspace-env", []string{}, "Extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
+	upCmd.Flags().StringSliceVar(&cmd.WorkspaceEnvFile, "workspace-env-file", []string{}, "The path to files containing a list of extra env variables to put into the workspace. E.g. MY_ENV_VAR=MY_VALUE")
+	upCmd.Flags().StringArrayVar(&cmd.InitEnv, "init-env", []string{}, "Extra env variables to inject during the initialization of the workspace. E.g. MY_ENV_VAR=MY_VALUE")
 	upCmd.Flags().StringVar(&cmd.ID, "id", "", "The id to use for the workspace")
 	upCmd.Flags().StringVar(&cmd.Machine, "machine", "", "The machine to use for this workspace. The machine needs to exist beforehand or the command will fail. If the workspace already exists, this option has no effect")
-	flags.StringVarE(upCmd.Flags(), &cmd.IDE, "ide", flags.DevpodEnvPrefix+"IDE", "", "The IDE to open the workspace in. If empty will use vscode locally or in browser")
+	upCmd.Flags().StringVar(&cmd.IDE, "ide", "", "The IDE to open the workspace in. If empty will use vscode locally or in browser")
 	upCmd.Flags().BoolVar(&cmd.OpenIDE, "open-ide", true, "If this is false and an IDE is configured, DevPod will only install the IDE server backend, but not open it")
 	upCmd.Flags().Var(&cmd.GitCloneStrategy, "git-clone-strategy", "The git clone strategy DevPod uses to checkout git based workspaces. Can be full (default), blobless, treeless or shallow")
 	upCmd.Flags().BoolVar(&cmd.GitCloneRecursiveSubmodules, "git-clone-recursive-submodules", false, "If true will clone git submodule repositories recursively")
 	upCmd.Flags().StringVar(&cmd.GitSSHSigningKey, "git-ssh-signing-key", "", "The ssh key to use when signing git commits. Used to explicitly setup DevPod's ssh signature forwarding with given key. Should be same format as value of `git config user.signingkey`")
-	flags.StringVarE(upCmd.Flags(), &cmd.FallbackImage, "fallback-image", flags.DevpodEnvPrefix+"FALLBACK_IMAGE", "", "The fallback image to use if no devcontainer configuration has been detected")
+	upCmd.Flags().StringVar(&cmd.FallbackImage, "fallback-image", "", "The fallback image to use if no devcontainer configuration has been detected")
 	upCmd.Flags().BoolVar(&cmd.DisableDaemon, "disable-daemon", false, "If enabled, will not install a daemon into the target machine to track activity")
 	upCmd.Flags().StringVar(&cmd.Source, "source", "", "Optional source for the workspace. E.g. git:https://github.com/my-org/my-repo")
 	upCmd.Flags().StringVar(&cmd.Userns, "userns", "", "User namespace to use for the container (Podman only; e.g. \"keep-id\", \"host\", or \"auto\")")
@@ -1064,7 +1064,7 @@ func mergeEnvFromFiles(baseOptions *provider2.CLIOptions) error {
 	return nil
 }
 
-var propagatedEnvironmentVariables = []string{
+var inheritedEnvironmentVariables = []string{
 	"GIT_AUTHOR_NAME",
 	"GIT_AUTHOR_EMAIL",
 	"GIT_AUTHOR_DATE",
@@ -1421,7 +1421,7 @@ func (cmd *UpCmd) prepareClient(ctx context.Context, devPodConfig *config.Config
 		return nil, logger, err
 	}
 
-	cmd.WorkspaceEnv = options2.PropagateFromEnvironment(cmd.WorkspaceEnv, propagatedEnvironmentVariables, "")
+	cmd.WorkspaceEnv = options2.InheritFromEnvironment(cmd.WorkspaceEnv, inheritedEnvironmentVariables, "")
 
 	var source *provider2.WorkspaceSource
 	if cmd.Source != "" {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -9,12 +9,12 @@ import (
 
 // Takes a list of assignments in KEY=VALUE format, a map of option to propagate, and an environment variable prefix,
 // and returns a new list with additional assignments from environment variables for any options not already assigned.
-func PropagateOptionsFromEnvironment[Map ~map[string]V, V any](
+func InheritOptionsFromEnvironment[Map ~map[string]V, V any](
 	assignments []string,
 	options Map,
 	prefix string,
 ) []string {
-	return PropagateFromEnvironment(
+	return InheritFromEnvironment(
 		assignments,
 		slices.Collect(maps.Keys(options)),
 		strings.ToUpper(prefix),
@@ -23,7 +23,7 @@ func PropagateOptionsFromEnvironment[Map ~map[string]V, V any](
 
 // Takes a list of assignments in KEY=VALUE format, a list of option names to check, and an environment variable prefix,
 // and returns a new list with additional assignments from environment variables for any names not already assigned.
-func PropagateFromEnvironment(
+func InheritFromEnvironment(
 	assignments []string,
 	names []string,
 	prefix string,

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -20,7 +20,7 @@ type assignmentTestCase struct {
 	ExpectedAssignments []string
 }
 
-func TestPropagateFromEnvironment(t *testing.T) {
+func TestInheritFromEnvironment(t *testing.T) {
 	testCases := []assignmentTestCase{
 		{
 			Name: "assigned, not in the environment",
@@ -102,7 +102,7 @@ func TestPropagateFromEnvironment(t *testing.T) {
 			}
 		}
 
-		result := PropagateFromEnvironment(testCase.Assignments, testCase.Names, testCase.EnvironmentVariablePrefix)
+		result := InheritFromEnvironment(testCase.Assignments, testCase.Names, testCase.EnvironmentVariablePrefix)
 
 		assert.DeepEqual(t, result, testCase.ExpectedAssignments)
 	}


### PR DESCRIPTION
Tighter integration with the `spf13/pflag` and `spf13/cobra` libraries allows for a better approach to setting default values of the CLI flags from the environment variables:
- this defaulting is done in one place (`root.go`);
- all the code enabling defaulting of specific flags is reverted;
- all the flags of all the commands can now be defaulted using environment variables;
- names of the environment variables are calculated from the names of the flags in a consistent way;
- there is no need to duplicate `pflag` code for the parsing of the non-string flags.