### PR TITLE
chore: replace gRPC build script with task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,6 +44,15 @@ tasks:
     cmds:
       - rm -rf "${TMPDIR:-/tmp/}devpod-cache"
 
+  cli:build:grpc:
+    desc: build devpod gRPC code
+    dir: pkg/agent/tunnel
+    cmd: |
+      # sudo apt install protobuf-compiler
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+      protoc -I . tunnel.proto --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative
+
   cli:test:
     desc: run devpod unit tests
     cmd: go test $(go list ./... | grep -v -e /test -e /e2e) -race -coverprofile=dist/profile.out -covermode=atomic

--- a/hack/build-grpc.sh
+++ b/hack/build-grpc.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# sudo apt install protobuf-compiler
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-
-cd pkg/agent/tunnel/ || exit
-protoc -I . tunnel.proto --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated gRPC build functionality from a standalone shell script into the Taskfile task system as `cli:build:grpc`.
  * The new task handles protoc plugin installation and code generation from tunnel.proto within the pkg/agent/tunnel directory.
  * Removed the separate shell script in favor of centralized build task management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->