### PR TITLE
ci: require secret for build label

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -142,7 +142,7 @@ jobs:
             runner: ubuntu-latest
             free-disk-space: true
             install-kind: true
-            requires-secret: false
+            requires-secret: true
 
           - label: up && workspace
             runner: ubuntu-latest


### PR DESCRIPTION
This allows contributors (e.g., non-collaborators) to run tests without failing due to requiring private token

Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance security controls for integration testing builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->