### PR TITLE
perf(driver/docker): emit docker buildx error logs when build fails

### DIFF
--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -211,9 +211,9 @@ func (d *dockerDriver) buildxBuild(ctx context.Context, writer io.Writer, platfo
 	err := d.Docker.Run(ctx, args, nil, writer, multiWriter)
 	if err != nil {
 		if stderrBuf.Len() > 0 {
-			return fmt.Errorf("failed to build image %w %s", err, strings.TrimSpace(stderrBuf.String()))
+			return fmt.Errorf("failed to build image: %w: %s", err, strings.TrimSpace(stderrBuf.String()))
 		}
-		return fmt.Errorf("build image %w", err)
+		return fmt.Errorf("failed to build image: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker build failure messages by capturing and including build tool stderr output, giving more detailed and actionable error information when image builds fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->