### PR TITLE
feat: add SSH_CONFIG_INCLUDE_PATH to support read-only ssh configs

### DIFF
--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -81,7 +81,7 @@ func (cmd *UpCmd) Run(ctx context.Context) error {
 
 	tunnelClient, logger, credentialsDir, err := initWorkspace(cancelCtx, cancel, workspaceInfo, cmd.Debug, !workspaceInfo.CLIOptions.Platform.Enabled && !workspaceInfo.CLIOptions.DisableDaemon)
 	if err != nil {
-		err1 := clientimplementation.DeleteWorkspaceFolder(workspaceInfo.Workspace.Context, workspaceInfo.Workspace.ID, workspaceInfo.Workspace.SSHConfigPath, logger)
+		err1 := clientimplementation.DeleteWorkspaceFolder(workspaceInfo.Workspace.Context, workspaceInfo.Workspace.ID, workspaceInfo.Workspace.SSHConfigPath, workspaceInfo.Workspace.SSHConfigIncludePath, logger)
 		if err1 != nil {
 			return fmt.Errorf("%s %w", err1.Error(), err)
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -88,6 +88,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 				cmd.DevContainerImage,
 				cmd.DevContainerPath,
 				sshConfigPath,
+				"",
 				nil,
 				cmd.UID,
 				false,

--- a/cmd/pro/delete.go
+++ b/cmd/pro/delete.go
@@ -143,7 +143,7 @@ func cleanupLocalWorkspaces(ctx context.Context, devPodConfig *config.Config, wo
 					return
 				}
 				// delete workspace folder
-				err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, client.Workspace(), client.WorkspaceConfig().SSHConfigPath, log)
+				err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, client.Workspace(), client.WorkspaceConfig().SSHConfigPath, client.WorkspaceConfig().SSHConfigIncludePath, log)
 				if err != nil {
 					log.WithFields(logrus.Fields{
 						"workspaceId": w.ID,

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -128,7 +128,7 @@ func (cmd *SSHCmd) Run(
 	// get user
 	if cmd.User == "" {
 		var err error
-		cmd.User, err = devssh.GetUser(client.WorkspaceConfig().ID, client.WorkspaceConfig().SSHConfigPath)
+		cmd.User, err = devssh.GetUser(client.WorkspaceConfig().ID, client.WorkspaceConfig().SSHConfigPath, client.WorkspaceConfig().SSHConfigIncludePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/client/clientimplementation/daemonclient/delete.go
+++ b/pkg/client/clientimplementation/daemonclient/delete.go
@@ -27,7 +27,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 		return err
 	} else if workspace == nil {
 		// delete the workspace folder
-		err = clientimplementation.DeleteWorkspaceFolder(c.workspace.Context, c.workspace.ID, c.workspace.SSHConfigPath, c.log)
+		err = clientimplementation.DeleteWorkspaceFolder(c.workspace.Context, c.workspace.ID, c.workspace.SSHConfigPath, c.workspace.SSHConfigIncludePath, c.log)
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 	}
 
 	// delete the workspace folder
-	err = clientimplementation.DeleteWorkspaceFolder(c.workspace.Context, c.workspace.ID, c.workspace.SSHConfigPath, c.log)
+	err = clientimplementation.DeleteWorkspaceFolder(c.workspace.Context, c.workspace.ID, c.workspace.SSHConfigPath, c.workspace.SSHConfigIncludePath, c.log)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -317,7 +317,7 @@ func (s *proxyClient) Delete(ctx context.Context, opt client.DeleteOptions) erro
 		s.log.Errorf("Error deleting workspace: %v", err)
 	}
 
-	return DeleteWorkspaceFolder(s.workspace.Context, s.workspace.ID, s.workspace.SSHConfigPath, s.log)
+	return DeleteWorkspaceFolder(s.workspace.Context, s.workspace.ID, s.workspace.SSHConfigPath, s.workspace.SSHConfigIncludePath, s.log)
 }
 
 func (s *proxyClient) Stop(ctx context.Context, opt client.StopOptions) error {

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -410,7 +410,7 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 		}
 	}
 
-	return DeleteWorkspaceFolder(s.workspace.Context, s.workspace.ID, s.workspace.SSHConfigPath, s.log)
+	return DeleteWorkspaceFolder(s.workspace.Context, s.workspace.ID, s.workspace.SSHConfigPath, s.workspace.SSHConfigIncludePath, s.log)
 }
 
 func (s *workspaceClient) isMachineRunning(ctx context.Context) (bool, error) {
@@ -643,14 +643,22 @@ func DeleteMachineFolder(context, machineID string) error {
 	return nil
 }
 
-func DeleteWorkspaceFolder(context string, workspaceID string, sshConfigPath string, log log.Logger) error {
+func DeleteWorkspaceFolder(context string, workspaceID string, sshConfigPath string, sshConfigIncludePath string, log log.Logger) error {
 	path, err := ssh.ResolveSSHConfigPath(sshConfigPath)
 	if err != nil {
 		return err
 	}
 	sshConfigPath = path
 
-	err = ssh.RemoveFromConfig(workspaceID, sshConfigPath, log)
+	if sshConfigIncludePath != "" {
+		includePath, err := ssh.ResolveSSHConfigPath(sshConfigIncludePath)
+		if err != nil {
+			return err
+		}
+		sshConfigIncludePath = includePath
+	}
+
+	err = ssh.RemoveFromConfig(workspaceID, sshConfigPath, sshConfigIncludePath, log)
 	if err != nil {
 		log.Errorf("Remove workspace '%s' from ssh config: %v", workspaceID, err)
 	}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -19,6 +19,7 @@ const (
 	ContextOptionDotfilesScript             = "DOTFILES_SCRIPT"
 	ContextOptionSSHAgentForwarding         = "SSH_AGENT_FORWARDING"
 	ContextOptionSSHConfigPath              = "SSH_CONFIG_PATH"
+	ContextOptionSSHConfigIncludePath       = "SSH_CONFIG_INCLUDE_PATH"
 	ContextOptionAgentInjectTimeout         = "AGENT_INJECT_TIMEOUT"
 	ContextOptionRegistryCache              = "REGISTRY_CACHE"
 	ContextOptionSSHStrictHostKeyChecking   = "SSH_STRICT_HOST_KEY_CHECKING"
@@ -88,6 +89,10 @@ var ContextOptions = []ContextOption{
 	{
 		Name:        ContextOptionSSHConfigPath,
 		Description: "Specifies the path where the ssh config should be written to",
+	},
+	{
+		Name:        ContextOptionSSHConfigIncludePath,
+		Description: "Specifies an alternate path where DevPod host entries should be written. Use this when your main SSH config is read-only (e.g., managed by Nix). Your main SSH config should have an Include directive pointing to this file.",
 	},
 	{
 		Name:        ContextOptionAgentInjectTimeout,

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -70,6 +70,9 @@ type Workspace struct {
 
 	// Path to the file where the SSH config to access the workspace is stored
 	SSHConfigPath string `json:"sshConfigPath,omitempty"`
+
+	// Path to an alternate file where DevPod entries are written (for read-only SSH configs)
+	SSHConfigIncludePath string `json:"sshConfigIncludePath,omitempty"`
 }
 
 type ProMetadata struct {

--- a/pkg/workspace/delete.go
+++ b/pkg/workspace/delete.go
@@ -36,7 +36,7 @@ func Delete(ctx context.Context, devPodConfig *config.Config, args []string, ign
 		log.Errorf("Error retrieving workspace: %v", err)
 
 		// delete workspace folder
-		err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, workspaceID, "", log)
+		err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, workspaceID, "", "", log)
 		if err != nil {
 			return "", err
 		}
@@ -52,7 +52,7 @@ func Delete(ctx context.Context, devPodConfig *config.Config, args []string, ign
 	workspaceConfig := client.WorkspaceConfig()
 	if !force && workspaceConfig.Imported {
 		// delete workspace folder
-		err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, client.Workspace(), workspaceConfig.SSHConfigPath, log)
+		err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, client.Workspace(), workspaceConfig.SSHConfigPath, workspaceConfig.SSHConfigIncludePath, log)
 		if err != nil {
 			return "", err
 		}
@@ -138,7 +138,7 @@ func deleteSingleMachine(ctx context.Context, client client2.BaseWorkspaceClient
 	}
 
 	// delete workspace folder
-	err = clientimplementation.DeleteWorkspaceFolder(client.Context(), client.Workspace(), client.WorkspaceConfig().SSHConfigPath, log)
+	err = clientimplementation.DeleteWorkspaceFolder(client.Context(), client.Workspace(), client.WorkspaceConfig().SSHConfigPath, client.WorkspaceConfig().SSHConfigIncludePath, log)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -53,7 +53,7 @@ func List(ctx context.Context, devPodConfig *config.Config, skipPro bool, owner 
 		for _, localWorkspace := range localWorkspaces {
 			if localWorkspace.IsPro() {
 				if shouldDeleteLocalWorkspace(ctx, localWorkspace, proWorkspaceResults) {
-					err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, localWorkspace.ID, "", log)
+					err = clientimplementation.DeleteWorkspaceFolder(devPodConfig.DefaultContext, localWorkspace.ID, localWorkspace.SSHConfigPath, localWorkspace.SSHConfigIncludePath, log)
 					if err != nil {
 						log.Debugf("failed to delete local workspace %s: %v", localWorkspace.ID, err)
 					}


### PR DESCRIPTION
References https://github.com/loft-sh/devpod/pull/1944

Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying an alternate SSH config include path. This allows DevPod to write host entries to a separate file when your main SSH config is read-only (e.g., managed by system tools). Your main SSH config should include a directive pointing to this alternate file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->