### PR TITLE
chore(agent/container): remove deprecated release-channel flag

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -518,7 +518,7 @@ func (cmd *SetupContainerCmd) setupVSCode(setupInfo *config.Result, ideOptions m
 		args := []string{
 			"agent", "container", "vscode-async",
 			"--setup-info", cmd.SetupInfo,
-			"--release-channel", string(flavor),
+			"--flavor", string(flavor),
 		}
 
 		return exec.Command(binaryPath, args...), nil

--- a/cmd/agent/container/vscode_async.go
+++ b/cmd/agent/container/vscode_async.go
@@ -9,7 +9,6 @@ import (
 	"github.com/skevetter/devpod/pkg/ide/vscode"
 	"github.com/skevetter/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // VSCodeAsyncCmd holds the cmd flags
@@ -33,19 +32,7 @@ func NewVSCodeAsyncCmd() *cobra.Command {
 	_ = vsCodeAsyncCmd.MarkFlagRequired("setup-info")
 
 	vsCodeAsyncCmd.Flags().StringVar(&cmd.Flavor, "flavor", string(vscode.FlavorStable), "The flavor of the VSCode distribution")
-	vsCodeAsyncCmd.Flags().StringVar(&cmd.Flavor, "release-channel", string(vscode.FlavorStable), "The release channel to use for vscode")
-	_ = vsCodeAsyncCmd.Flags().MarkDeprecated("release-channel", "prefer the --flavor flag")
-	// gracefully migrate --release-channel to --flavor
-	vsCodeAsyncCmd.Flags().SetNormalizeFunc(migrateReleaseChannel)
 	return vsCodeAsyncCmd
-}
-
-func migrateReleaseChannel(f *pflag.FlagSet, name string) pflag.NormalizedName {
-	if name == "release-channel" {
-		name = "flavor"
-	}
-
-	return pflag.NormalizedName(name)
 }
 
 // Run runs the command logic


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the deprecated `--release-channel` flag from the container setup. Use the `--flavor` flag to configure the VS Code container setup instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->