### PR TITLE
refactor(ui): set default devcontainer image to ubuntu

### DIFF
--- a/desktop/src/views/Workspaces/CreateWorkspace/WorkspaceSourceInput.tsx
+++ b/desktop/src/views/Workspaces/CreateWorkspace/WorkspaceSourceInput.tsx
@@ -260,7 +260,11 @@ export function WorkspaceSourceInput({
           </Popover>
         </TabPanel>
         <TabPanel {...tabPanelProps}>
-          <Input {...inputCommonProps} width="full" placeholder="mcr.microsoft.com/devcontainers/base:ubuntu" />
+          <Input
+            {...inputCommonProps}
+            width="full"
+            placeholder="mcr.microsoft.com/devcontainers/base:ubuntu"
+          />
         </TabPanel>
       </TabPanels>
     </Tabs>


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default image source placeholder shown during workspace creation from "alpine" to "mcr.microsoft.com/devcontainers/base:ubuntu" to give clearer, more specific guidance to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->