### PR TITLE
revert(devcontainer/config): remove ssh timeout because it does not update the user's IDE

### DIFF
--- a/pkg/devcontainer/config/result.go
+++ b/pkg/devcontainer/config/result.go
@@ -80,25 +80,12 @@ func GetDevPodCustomizations(parsedConfig *DevContainerConfig) *DevPodCustomizat
 }
 
 func GetVSCodeConfiguration(mergedConfig *MergedDevContainerConfig) *VSCodeCustomizations {
-	// NOTE: These defaults will be overridden by the user settings in devcontainer.json
-	// or by the user's settings.
-	defaults := map[string]any{
-		// NOTE: The default remote.SSH.connectTimeout is 15 seconds.
-		// This value has been increased to 30 seconds to help with latency issues
-		// causing SSH connections to timeout intermittently with the AWS provider.
-		//
-		// Example error via the "Remote-SSH" VSCode output panel:
-		// Running ssh connection command: ssh -v -T -D 61240 -o ConnectTimeout=15 <workspace-identifier.devpod>
-		// Resolver error: Error: The connection timed out
-		"remote.SSH.connectTimeout": 30,
-	}
-
 	if mergedConfig.Customizations == nil || mergedConfig.Customizations["vscode"] == nil {
-		return &VSCodeCustomizations{Settings: defaults}
+		return &VSCodeCustomizations{}
 	}
 
 	retVSCodeCustomizations := &VSCodeCustomizations{
-		Settings:   maps.Clone(defaults),
+		Settings:   map[string]any{},
 		Extensions: nil,
 	}
 	for _, customization := range mergedConfig.Customizations["vscode"] {


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic injection of default VSCode settings in development container configurations. The application will no longer automatically apply default values to remote.SSH timeout settings. Users now have complete control over their VSCode configuration preferences without unwanted defaults unless explicitly specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->