### PR TITLE
fix(driver/docker): allow all OS to detect podman

### DIFF
--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -587,7 +587,7 @@ func (d *dockerDriver) GetDevContainerLogs(ctx context.Context, workspaceId stri
 }
 
 func (d *dockerDriver) getPodmanArgs(options *driver.RunOptions, parsedConfig *config.DevContainerConfig) ([]string, error) {
-	if !d.Docker.IsPodman() || runtime.GOOS != "linux" {
+	if !d.Docker.IsPodman() {
 		return []string{}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Podman support on Windows and macOS by enabling consistent configuration behavior across all operating systems. Previously, Podman on non-Linux systems would skip certain setup steps; this has been corrected for parity with Linux.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->