### PR TITLE
fix(vscode/open): remove leading slash from folder URI

### DIFF
--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -104,10 +104,6 @@ func openViaBrowser(params OpenParams) error {
 
 	folder := strings.TrimPrefix(params.Folder, "/")
 	pathStr := fmt.Sprintf("/ssh-remote+%s.devpod/%s", params.Workspace, folder)
-	if folder != "" {
-		pathStr += "/" + folder
-	}
-
 	u := &url.URL{
 		Scheme: config.scheme,
 		Host:   "vscode-remote",


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable VS Code remote URL and folder argument construction: workspace paths (including leading slashes) are handled consistently when opening.
  * Improved handling when opening in a new window; query parameters for new-window requests are now applied consistently.
  * More robust browser-open behavior with improved logging for troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->