### PR TITLE
Add a newline after `devpod version` output

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -27,6 +27,6 @@ func NewVersionCmd() *cobra.Command {
 
 // Run runs the command logic
 func (cmd *VersionCmd) Run(_ *cobra.Command, _ []string) error {
-	_, _ := fmt.Fprintln(os.Stdout, version.GetVersion())
+	_, _ = fmt.Fprintln(os.Stdout, version.GetVersion())
 	return nil
 }


### PR DESCRIPTION
Avoids this:

<img width="237" height="44" alt="image" src="https://github.com/user-attachments/assets/be4f820d-8c0a-49b7-86c1-e3112140e10a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed how the version text is written to standard output.
  * Write operation now ignores any write errors and will not cause an error exit on failure.
  * Normal behavior remains unchanged when printing succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->