### PR TITLE
fix(devcontainer): strip digest refs in compose feature build override

### DIFF
--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -629,6 +629,9 @@ func (r *runner) extendedDockerComposeBuild(composeService *composetypes.Service
 			Context:    filepath.Dir(featuresBuildInfo.FeaturesFolder),
 		},
 	}
+	if composeService.Image != "" {
+		service.Image = stripDigestFromImageRef(composeService.Image)
+	}
 
 	if composeService.Build != nil && composeService.Build.Target != "" {
 		service.Build.Target = featuresBuildInfo.OverrideTarget
@@ -669,6 +672,15 @@ func (r *runner) extendedDockerComposeBuild(composeService *composetypes.Service
 	}
 
 	return dockerComposePath, nil
+}
+
+func stripDigestFromImageRef(imageRef string) string {
+	baseRef, _, found := strings.Cut(imageRef, "@")
+	if !found {
+		return imageRef
+	}
+
+	return baseRef
 }
 
 func (r *runner) extendedDockerComposeUp(

--- a/pkg/devcontainer/compose_test.go
+++ b/pkg/devcontainer/compose_test.go
@@ -1,0 +1,40 @@
+package devcontainer
+
+import "testing"
+
+func TestStripDigestFromImageRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "digest reference",
+			input: "registry.example.com/app:1.2.3@sha256:abcdef",
+			want:  "registry.example.com/app:1.2.3",
+		},
+		{
+			name:  "no digest",
+			input: "registry.example.com/app:1.2.3",
+			want:  "registry.example.com/app:1.2.3",
+		},
+		{
+			name:  "digest without tag",
+			input: "registry.example.com/app@sha256:abcdef",
+			want:  "registry.example.com/app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := stripDigestFromImageRef(tt.input)
+			if got != tt.want {
+				t.Fatalf("stripDigestFromImageRef(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- avoid Docker Compose build failures when the service image is digest-pinned (`image: repo:tag@sha256:...`) and features are enabled
- normalize image refs in the temporary compose build override by stripping the digest suffix before tagging
- add unit tests for digest and non-digest image reference handling

## Validation
- go test ./pkg/devcontainer
- reproduced the original `refusing to create a tag with a digest reference` failure before the change
- verified `go run . up --debug --reset --recreate --devcontainer-path .devcontainer/hawk-monorepo/devcontainer.json ~/lgt/hawk` passes the previous build/tagging failure path after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker Compose image handling now strips digest fragments from image references, ensuring consistent image identification and processing across formats.

* **Tests**
  * Added unit tests covering image reference handling with and without digest information to improve reliability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->