### PR TITLE
fix(desktop): Strip newlines from PATH

### DIFF
--- a/desktop/src-tauri/src/fix_env.rs
+++ b/desktop/src-tauri/src/fix_env.rs
@@ -42,7 +42,7 @@ pub fn fix_env(var_name: &str) -> Result<(), Error> {
 
         if out.status.success() {
             let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-            let cleaned = &strip_ansi_escapes::strip(stdout)?;
+            let cleaned = &strip_ansi_escapes::strip(stdout.trim())?;
             let value = String::from_utf8_lossy(cleaned);
             unsafe {
                 std::env::set_var(var_name, value.as_ref());


### PR DESCRIPTION
On Linux, the desktop app attempts to discover `PATH` by calling `printenv`
and then post-processing this output. On Fedora 43 with the Fish shell
(at least), this results in PATH being set to
`/usr/local/bin:/usr/bin\n` (note the trailing newline), which then
prevents the desktop app from even starting:

```
Gtk:ERROR:../gtk/gtkiconhelper.c:495:ensure_surface_for_gicon:
assertion failed (error == NULL): Failed to load
/usr/share/icons/Adwaita/scalable/status/image-missing.svg: Could not
spawn the following command. Is the used binary available? `"bwrap" ...`:
No such file or directory (os error 2) (gdk-pixbuf-error-quark, 0)
```

The error message is confusing, as bwrap is available. strace shows
the actual problem:

```
[pid 1136345] execve("/usr/bin\n/bwrap", ["bwrap", "--unshare-all", "--die-with-parent", "--chd
```

Ensure no newlines are left in PATH by trimming the output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable handling: command output is now trimmed of surrounding whitespace prior to processing, ensuring stray spaces or newlines no longer interfere with ANSI-stripping and subsequent environment value setting. This prevents incorrect, empty, or improperly parsed values and improves reliability when capturing values produced by external commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->