### PR TITLE
fix: make userenvprobe handle unusual environment variables better

### DIFF
--- a/pkg/devcontainer/config/userenvprobe_test.go
+++ b/pkg/devcontainer/config/userenvprobe_test.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/skevetter/log"
+)
+
+//nolint:funlen,lll // It's just test input vectors.
+func TestParseProbeOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   []byte
+		sep      byte
+		expected map[string]string
+	}{
+		{
+			name:   "simple environment variables with null separator",
+			output: []byte("PATH=/usr/bin\x00HOME=/home/user\x00USER=testuser\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"PATH": "/usr/bin",
+				"HOME": "/home/user",
+				"USER": "testuser",
+			},
+		},
+		{
+			name:   "environment variable with multiple equals signs",
+			output: []byte("SIMPLE=value\x00COMPLEX=key=value=more\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"SIMPLE":  "value",
+				"COMPLEX": "key=value=more",
+			},
+		},
+		{
+			name:   "bash function with newlines and special characters",
+			output: []byte("BASH_FUNC_scl%%=() {  if [ \"$1\" = \"load\" -o \"$1\" = \"unload\" ]; then\n eval \"module $@\";\n else\n /usr/bin/scl \"$@\";\n fi\n}\x00PATH=/usr/bin\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"BASH_FUNC_scl%%": "() {  if [ \"$1\" = \"load\" -o \"$1\" = \"unload\" ]; then\n eval \"module $@\";\n else\n /usr/bin/scl \"$@\";\n fi\n}",
+				"PATH":            "/usr/bin",
+			},
+		},
+		{
+			name:   "environment variable with leading and trailing whitespace",
+			output: []byte("VAR1=  value with spaces  \x00VAR2=\tvalue with tab\t\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"VAR1": "  value with spaces  ",
+				"VAR2": "\tvalue with tab\t",
+			},
+		},
+		{
+			name:   "environment variable with newlines in value",
+			output: []byte("MULTILINE=line1\nline2\nline3\x00SIMPLE=test\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"MULTILINE": "line1\nline2\nline3",
+				"SIMPLE":    "test",
+			},
+		},
+		{
+			name:     "empty output",
+			output:   []byte(""),
+			sep:      '\x00',
+			expected: map[string]string{},
+		},
+		{
+			name:   "environment variable with empty value",
+			output: []byte("EMPTY=\x00NONEMPTY=value\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"EMPTY":    "",
+				"NONEMPTY": "value",
+			},
+		},
+		{
+			name:   "invalid entry without equals sign",
+			output: []byte("INVALID\x00VALID=value\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"VALID": "value",
+			},
+		},
+		{
+			name:   "newline separator (printenv format)",
+			output: []byte("PATH=/usr/bin\nHOME=/home/user\nUSER=testuser\n"),
+			sep:    '\n',
+			expected: map[string]string{
+				"PATH": "/usr/bin",
+				"HOME": "/home/user",
+				"USER": "testuser",
+			},
+		},
+		{
+			name:   "complex bash function with multiple newlines",
+			output: []byte("BASH_FUNC_module%%=() {\n eval `/usr/bin/modulecmd bash $*`\n}\x00SHELL=/bin/bash\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"BASH_FUNC_module%%": "() {\n eval `/usr/bin/modulecmd bash $*`\n}",
+				"SHELL":              "/bin/bash",
+			},
+		},
+		{
+			name:   "environment variable with equals in value at start",
+			output: []byte("VAR==value\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"VAR": "=value",
+			},
+		},
+		{
+			name:   "multiple consecutive equals signs",
+			output: []byte("VAR1===\x00VAR2=a=b=c=d\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"VAR1": "==",
+				"VAR2": "a=b=c=d",
+			},
+		},
+		{
+			name:   "bash function from RHEL",
+			output: []byte("BASH_FUNC_scl%%=() {  if [ \"$1\" = \"load\" -o \"$1\" = \"unload\" ]; then\n eval \"module $@\";\n else\n /usr/bin/scl \"$@\";\n fi\n}\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"BASH_FUNC_scl%%": "() {  if [ \"$1\" = \"load\" -o \"$1\" = \"unload\" ]; then\n eval \"module $@\";\n else\n /usr/bin/scl \"$@\";\n fi\n}",
+			},
+		},
+		{
+			name:     "trailing separator only",
+			output:   []byte("\x00"),
+			sep:      '\x00',
+			expected: map[string]string{},
+		},
+		{
+			name:   "multiple trailing separators",
+			output: []byte("VAR=value\x00\x00\x00"),
+			sep:    '\x00',
+			expected: map[string]string{
+				"VAR": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLogger := log.Default.ErrorStreamOnly()
+			result := parseProbeOutput(tt.output, tt.sep, testLogger)
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseProbeOutput() mismatch\ngot:  %+v\nwant: %+v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The userenvprobe reads `/proc/self/environ` from the target (container)
environment to then pass it on as environment variables when executing,
for example, the lifecycle hooks (like `postStartCommand` in
`devcontainer.json`).

`/proc/self/environ` provides a NULL-delimited list of NAME=VALUE pairs.
The VALUE in some environment variables can be rather long and contain
newlines and other "unusual" characters. An example for such a long
environment variable is the following one, which is set by default in
Red Hat Enterprise Linux-derived distributions (scl is a command to
switch software collections):

```
BASH_FUNC_scl%%=() {  if [ "$1" = "load" -o "$1" = "unload" ]; then
 eval "module $@";
 else
 /usr/bin/scl "$@";
 fi
}
```

Before this commit, this environment variable would be parsed as

```
BASH_FUNC_scl%%=() {  if [ "$1"
```

I.e., everything after the second `=` would be discarded. Down the line,
this led to errors like the following when running any lifecycle hook:

```
bash: scl: line 1: syntax error: unexpected end of file tunnelserver.go:366
bash: error importing function definition for `scl' tunnelserver.go:366
bash: switchml: line 1: syntax error: unexpected end of file tunnelserver.go:366
bash: error importing function definition for `switchml' tunnelserver.go:366
bash: module: line 2: syntax error: unexpected end of file tunnelserver.go:366
bash: error importing function definition for `module' tunnelserver.go:366
...
```

Improve the parsing code to only do a single split on the `=` sign and
otherwise keep the variables as they are with less post-processing which
could go wrong (e.g., no stripping, no parsing magic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment variable parsing in development container configuration with enhanced handling of various input formats and edge cases.

* **Tests**
  * Added comprehensive test coverage for environment variable parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->