### PR TITLE
feat: expand user home directory references in workspace source

### DIFF
--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -336,6 +338,11 @@ func ParseWorkspaceSource(source string) *WorkspaceSource {
 			GitSubPath:     gitSubdir,
 		}
 	} else if after, ok := strings.CutPrefix(source, WorkspaceSourceLocal); ok {
+		// Expand home directory references (~) in the path.
+		if strings.HasPrefix(after, "~/") {
+			home, _ := os.UserHomeDir()
+			after = filepath.Join(home, after[2:])
+		}
 		return &WorkspaceSource{
 			LocalFolder: after,
 		}


### PR DESCRIPTION
When creating a new workspace expand tildes signs in the user-provided
local path to form an absolute directory. An absolute directory
reference is required later by the docker provider on in `docker run`
command. Perform the home directory expansion before storing the source
to give all providers a robust absolute path to work with (instead of
hoping they do tilde expansion themselves).

In the Desktop app, the user can enter and save the path with the tilde.
In the overview page, the path is then shown as expanded.

Here's an excerpt from the log showing the problem this commit solves:
```
info running docker command command=docker args=run --sig-proxy=false
--mount type=bind,src=~/src/my-project,dst=/workspaces/my-project
-u root -e DEVPOD=true -e REMOTE_CONTAINERS=true
-e DEVPOD_WORKSPACE_ID=my-project -e DEVPOD_WORKSPACE_UID=default-zr-a74e4
...

info docker: Error response from daemon: invalid mount config for type
"bind": invalid mount path: '~/src/my-project' mount path must be absolute
```
