### PR TITLE
fix(cmd/ssh): default ssh workdir to merged workspaceFolder

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -539,7 +539,7 @@ func resolveWorkdir(workdir string, workspaceClient client2.BaseWorkspaceClient,
 		return workspaceFolder
 	}
 
-	return filepath.Join("/workspaces", workspaceClient.Workspace())
+	return path.Join("/workspaces", workspaceClient.Workspace())
 }
 
 func resolveMergedWorkspaceFolder(workspaceClient client2.BaseWorkspaceClient, log log.Logger) string {


### PR DESCRIPTION
## Summary
- make `devpod ssh` prefer `mergedConfig.WorkspaceFolder` as the default workdir when `--workdir` is not provided
- keep `--workdir` as the highest-priority override and preserve fallback to `/workspaces/<workspace-id>` when no merged workspace folder is available
- add debug-level handling for workspace result load failures so SSH still connects using fallback behavior

Closes #516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workspace directory resolution for SSH sessions: prefers configured workspace folder when available, otherwise falls back to the workspace path.
  * Reworked SSH, GPG agent and forward-SSH invocation to build and quote commands safely, reducing shell injection risks.
  * Safer handling of flags and non-root execution so sessions run correctly when a non-root user is specified.
* **Bug Fixes**
  * Minor logging tweaks around command composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->