### PR TITLE
refactor(cmd/provider): update ConfigureProvider to use ProviderOptionsConfig struct

### DIFF
--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -197,8 +197,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log log.Logger) er
 
 	// 3. Configure provider
 	if cmd.Use {
-		err := providercmd.ConfigureProvider(providercmd.ProviderOptionsConfig{
-			Ctx:            ctx,
+		err := providercmd.ConfigureProvider(ctx, providercmd.ProviderOptionsConfig{
 			Provider:       providerConfig,
 			Context:        devPodConfig.DefaultContext,
 			UserOptions:    cmd.Options,

--- a/cmd/pro/update_provider.go
+++ b/cmd/pro/update_provider.go
@@ -76,8 +76,7 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("update provider %s: %w", provider.Name, err)
 	}
 
-	err = providercmd.ConfigureProvider(providercmd.ProviderOptionsConfig{
-		Ctx:            ctx,
+	err = providercmd.ConfigureProvider(ctx, providercmd.ProviderOptionsConfig{
 		Provider:       provider,
 		Context:        devPodConfig.DefaultContext,
 		UserOptions:    []string{},

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -96,8 +96,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devPodConfig *config.Config, args []
 		"providerName": providerConfig.Name,
 	}).Done("installed provider")
 	if cmd.Use {
-		configureErr := ConfigureProvider(ProviderOptionsConfig{
-			Ctx:            ctx,
+		configureErr := ConfigureProvider(ctx, ProviderOptionsConfig{
 			Provider:       providerConfig,
 			Context:        devPodConfig.DefaultContext,
 			UserOptions:    options,

--- a/cmd/provider/set_options.go
+++ b/cmd/provider/set_options.go
@@ -78,8 +78,7 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string, log log.Logger
 		return err
 	}
 
-	devPodConfig, err = configureProviderOptions(ProviderOptionsConfig{
-		Ctx:            ctx,
+	devPodConfig, err = configureProviderOptions(ctx, ProviderOptionsConfig{
 		Provider:       providerWithOptions.Config,
 		Context:        devPodConfig.DefaultContext,
 		UserOptions:    cmd.Options,

--- a/cmd/provider/update.go
+++ b/cmd/provider/update.go
@@ -64,8 +64,7 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devPodConfig *config.Config, args
 		"providerName": providerConfig.Name,
 	}).Done("updated provider")
 	if cmd.Use {
-		err = ConfigureProvider(ProviderOptionsConfig{
-			Ctx:            ctx,
+		err = ConfigureProvider(ctx, ProviderOptionsConfig{
 			Provider:       providerConfig,
 			Context:        devPodConfig.DefaultContext,
 			UserOptions:    cmd.Options,


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated provider configuration into a unified internal configuration flow for more consistent setup across commands.
  * No changes to user-facing behavior; provider setup, prompts, and error messages remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->