### PR TITLE
fix(tauri): exclude outdated libraries in AppImage build

### DIFF
--- a/desktop/src-tauri/tauri.linux.conf.json
+++ b/desktop/src-tauri/tauri.linux.conf.json
@@ -5,7 +5,14 @@
         "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
       },
       "appimage": {
-        "bundleMediaFramework": true
+        "bundleMediaFramework": true,
+        "linuxdeploy": {
+          "args": [
+            "--exclude-library=libseccomp.so.2",
+            "--exclude-library=libcrypto.so.3",
+            "--exclude-library=libssl.so.3"
+          ]
+        }
       },
       "rpm": {
         "depends": ["webkit2gtk4.1", "gtk3"]


### PR DESCRIPTION
references https://github.com/skevetter/devpod/issues/545

Per the excludelist, the libwayland-client should be [excluded](https://github.com/AppImageCommunity/pkg2appimage/blob/19e30b276ffedf4d3b4b56bc6320f463625a74f8/excludelist#L90C1-L94C1) from the AppImage build.

```
libwayland-client.so.0
# https://github.com/AppImageCommunity/pkg2appimage/pull/559
# https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316
# New version of Mesa has some dependency issues with libwayland-client if it is bundled
```

The AppImage [best practices](https://docs.appimage.org/reference/best-practices.html) recommends

> The AppImage needs to include all libraries and other dependencies that are not part of all of the base systems that the AppImage is intended to run on.

An interpretation of this section could mean that common libraries that are already part of the base system should be excluded.

Signed-off-by: Samuel K <skevetter@pm.me>
