### PR TITLE
refactor(devcontainer/sshtunnel): error and context handling for EOF errors in Windows e2e tests

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -808,8 +808,7 @@ func (cmd *UpCmd) devPodUpMachine(
 		})
 	}
 
-	return sshtunnel.ExecuteCommand(sshtunnel.ExecuteCommandOptions{
-		Ctx:            ctx,
+	return sshtunnel.ExecuteCommand(ctx, sshtunnel.ExecuteCommandOptions{
 		Client:         client,
 		AddPrivateKeys: devPodConfig.ContextOption(config.ContextOptionSSHAddPrivateKeys) == "true",
 		AgentInject:    agentInjectFunc,

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -270,8 +270,7 @@ func (r *runner) executeSetup(
 		)
 	}
 
-	return sshtunnel.ExecuteCommand(sshtunnel.ExecuteCommandOptions{
-		Ctx:              ctx,
+	return sshtunnel.ExecuteCommand(ctx, sshtunnel.ExecuteCommandOptions{
 		Client:           nil,
 		AddPrivateKeys:   false,
 		AgentInject:      agentInjectFunc,

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -190,7 +190,6 @@ func createPipes() (*pipePair, error) {
 
 type sshServerHelperParams struct {
 	opts         ExecuteCommandOptions
-	cancel       context.CancelFunc
 	stdinReader  *os.File
 	stdoutWriter *os.File
 	errChan      chan error
@@ -211,7 +210,6 @@ func isExpectedError(err error) bool {
 
 func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) {
 	defer p.opts.Log.Debug("done executing SSH server helper command")
-	defer p.cancel()
 
 	writer := p.opts.Log.Writer(logrus.InfoLevel, false)
 	defer func() { _ = writer.Close() }()

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -276,8 +276,6 @@ func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
 }
 
 func runSSHTunnel(ctx context.Context, tc *tunnelContext) {
-	defer tc.cancel()
-
 	tc.opts.Log.Debug("creating SSH client")
 	sshClient, err := devssh.StdioClient(tc.sshPipes.stdoutReader, tc.sshPipes.stdinWriter, false)
 	if err != nil {

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -98,7 +98,15 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	result, err := waitForTunnelCompletion(cancelCtx, tc)
 	wg.Wait() // Wait for goroutines to complete
 
-	return result, err
+	errs := collectTunnelErrors(tc, result)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return result, nil
+	}
+	return result, errors.Join(errs...)
 }
 
 func setupTunnelContext(
@@ -146,13 +154,7 @@ func waitForTunnelCompletion(ctx context.Context, tc *tunnelContext) (*config2.R
 	}
 
 	tc.opts.Log.Debug("awaiting tunnel server command completion")
-	errs := collectTunnelErrors(tc, result)
-	tc.opts.Log.Debug("SSH tunnel execution completed")
-
-	if len(errs) == 0 {
-		return result, nil
-	}
-	return result, errors.Join(errs...)
+	return result, nil
 }
 
 // collectTunnelErrors collects errors from both goroutines running in the SSH tunnel.

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -74,7 +74,7 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		executeSSHServerHelper(ctx, &sshServerHelperParams{
+		executeSSHServerHelper(cancelCtx, &sshServerHelperParams{
 			opts:         opts,
 			stdinReader:  tc.sshPipes.stdinReader,
 			stdoutWriter: tc.sshPipes.stdoutWriter,

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -22,6 +22,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+const (
+	// errorChannelBuffer is the size of the error channel buffer.
+	errorChannelBuffer = 2
+	// maxLogLines is the number of error lines to keep from tunnel output for debugging.
+	maxLogLines = 1
+)
+
 type (
 	AgentInjectFunc  func(context.Context, string, *os.File, *os.File, io.WriteCloser) error
 	TunnelServerFunc func(ctx context.Context, stdin io.WriteCloser, stdout io.Reader) (*config2.Result, error)
@@ -36,7 +43,6 @@ var logLevelMap = map[string]logrus.Level{
 }
 
 type ExecuteCommandOptions struct {
-	Ctx              context.Context
 	Client           client2.WorkspaceClient
 	AddPrivateKeys   bool
 	AgentInject      AgentInjectFunc
@@ -48,7 +54,6 @@ type ExecuteCommandOptions struct {
 
 type tunnelContext struct {
 	opts      ExecuteCommandOptions
-	cancelCtx context.Context
 	cancel    context.CancelFunc
 	errChan   chan error
 	sshPipes  *pipePair
@@ -56,11 +61,11 @@ type tunnelContext struct {
 }
 
 // ExecuteCommand runs the command in an SSH Tunnel and returns the result.
-func ExecuteCommand(opts ExecuteCommandOptions) (*config2.Result, error) {
+func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.Result, error) {
 	opts.Log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
 
-	tc, err := setupTunnelContext(opts)
+	cancelCtx, tc, err := setupTunnelContext(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -69,9 +74,8 @@ func ExecuteCommand(opts ExecuteCommandOptions) (*config2.Result, error) {
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		executeSSHServerHelper(&sshServerHelperParams{
+		executeSSHServerHelper(ctx, &sshServerHelperParams{
 			opts:         opts,
-			cancel:       tc.cancel,
 			stdinReader:  tc.sshPipes.stdinReader,
 			stdoutWriter: tc.sshPipes.stdoutWriter,
 			errChan:      tc.errChan,
@@ -79,40 +83,40 @@ func ExecuteCommand(opts ExecuteCommandOptions) (*config2.Result, error) {
 	})
 
 	if opts.AddPrivateKeys {
-		addPrivateKeys(opts)
+		addPrivateKeys(ctx, opts)
 	}
 
 	wg.Go(func() {
-		runSSHTunnel(tc)
+		runSSHTunnel(cancelCtx, tc)
 	})
 
-	result, err := waitForTunnelCompletion(tc)
-
-	// Wait for goroutines to complete
-	wg.Wait()
+	result, err := waitForTunnelCompletion(cancelCtx, tc)
+	wg.Wait() // Wait for goroutines to complete
 
 	return result, err
 }
 
-func setupTunnelContext(opts ExecuteCommandOptions) (*tunnelContext, error) {
+func setupTunnelContext(
+	ctx context.Context,
+	opts ExecuteCommandOptions,
+) (context.Context, *tunnelContext, error) {
 	sshPipes, err := createPipes()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	cancelCtx, cancel := context.WithCancel(opts.Ctx)
-	errChan := make(chan error, 2)
+	cancelCtx, cancel := context.WithCancel(ctx)
+	errChan := make(chan error, errorChannelBuffer)
 
 	grpcPipes, err := createPipes()
 	if err != nil {
 		sshPipes.Close()
 		cancel()
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &tunnelContext{
+	return cancelCtx, &tunnelContext{
 		opts:      opts,
-		cancelCtx: cancelCtx,
 		cancel:    cancel,
 		errChan:   errChan,
 		sshPipes:  sshPipes,
@@ -126,9 +130,9 @@ func (tc *tunnelContext) cleanup() {
 	tc.cancel()
 }
 
-func waitForTunnelCompletion(tc *tunnelContext) (*config2.Result, error) {
+func waitForTunnelCompletion(ctx context.Context, tc *tunnelContext) (*config2.Result, error) {
 	result, err := tc.opts.TunnelServerFunc(
-		tc.cancelCtx,
+		ctx,
 		tc.grpcPipes.stdinWriter,
 		tc.grpcPipes.stdoutReader,
 	)
@@ -137,25 +141,51 @@ func waitForTunnelCompletion(tc *tunnelContext) (*config2.Result, error) {
 	}
 
 	tc.opts.Log.Debug("awaiting tunnel server command completion")
-
-	// Collect both errors to handle race condition
-	var errs []error
-	err1 := <-tc.errChan
-	if err1 != nil {
-		errs = append(errs, err1)
-	}
-	err2 := <-tc.errChan
-	if err2 != nil {
-		errs = append(errs, err2)
-	}
-
+	errs := collectTunnelErrors(tc, result)
 	tc.opts.Log.Debug("SSH tunnel execution completed")
 
-	// Return first error or combine multiple errors
 	if len(errs) == 0 {
 		return result, nil
 	}
 	return result, errors.Join(errs...)
+}
+
+// collectTunnelErrors collects errors from both goroutines running in the SSH tunnel.
+// It expects two errors:
+//   - First error: from executeSSHServerHelper (SSH server injection and agent command execution)
+//   - Second error: from runSSHTunnel (SSH tunnel establishment and command execution)
+//
+// If a valid result was received, EOF errors during cleanup are ignored as they indicate
+// normal session termination after successful completion.
+func collectTunnelErrors(tc *tunnelContext, result *config2.Result) []error {
+	hasValidResult := result != nil
+	var errs []error
+
+	err1 := <-tc.errChan
+	if shouldReportError(err1, hasValidResult, tc.opts.Log) {
+		errs = append(errs, err1)
+	}
+
+	err2 := <-tc.errChan
+	if shouldReportError(err2, hasValidResult, tc.opts.Log) {
+		errs = append(errs, err2)
+	}
+
+	return errs
+}
+
+// shouldReportError determines if an error should be reported to the caller.
+// It returns false for nil errors and for EOF errors that occur during cleanup
+// after a successful result has been received.
+func shouldReportError(err error, hasValidResult bool, log log.Logger) bool {
+	if err == nil {
+		return false
+	}
+	if hasValidResult && isCleanupEOF(err) {
+		log.Debug("ignoring EOF during cleanup after successful result")
+		return false
+	}
+	return true
 }
 
 type pipePair struct {
@@ -199,7 +229,6 @@ func createPipes() (*pipePair, error) {
 
 type sshServerHelperParams struct {
 	opts         ExecuteCommandOptions
-	cancel       context.CancelFunc
 	stdinReader  *os.File
 	stdoutWriter *os.File
 	errChan      chan error
@@ -218,15 +247,14 @@ func isExpectedError(err error) bool {
 	return false
 }
 
-func executeSSHServerHelper(p *sshServerHelperParams) {
+func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) {
 	defer p.opts.Log.Debug("done executing SSH server helper command")
-	defer p.cancel()
 
 	writer := p.opts.Log.Writer(logrus.InfoLevel, false)
 	defer func() { _ = writer.Close() }()
 
 	p.opts.Log.Debugf("injecting and running SSH server command: %q", p.opts.SSHCommand)
-	err := p.opts.AgentInject(p.opts.Ctx, p.opts.SSHCommand, p.stdinReader, p.stdoutWriter, writer)
+	err := p.opts.AgentInject(ctx, p.opts.SSHCommand, p.stdinReader, p.stdoutWriter, writer)
 	if err != nil && !isExpectedError(err) {
 		p.errChan <- fmt.Errorf("executing agent command: %w", err)
 	} else {
@@ -234,15 +262,15 @@ func executeSSHServerHelper(p *sshServerHelperParams) {
 	}
 }
 
-func addPrivateKeys(opts ExecuteCommandOptions) {
+func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
 	opts.Log.Debug("adding SSH keys to agent")
-	err := devssh.AddPrivateKeysToAgent(opts.Ctx, opts.Log)
+	err := devssh.AddPrivateKeysToAgent(ctx, opts.Log)
 	if err != nil {
 		opts.Log.Debugf("failed to add private keys to SSH agent: %v", err)
 	}
 }
 
-func runSSHTunnel(tc *tunnelContext) {
+func runSSHTunnel(ctx context.Context, tc *tunnelContext) {
 	defer tc.cancel()
 
 	tc.opts.Log.Debug("creating SSH client")
@@ -257,7 +285,7 @@ func runSSHTunnel(tc *tunnelContext) {
 		tc.opts.Log.Debug("SSH client closed")
 	}()
 
-	sess, err := establishSSHSession(tc, sshClient)
+	sess, err := establishSSHSession(ctx, tc, sshClient)
 	if err != nil {
 		return
 	}
@@ -269,10 +297,11 @@ func runSSHTunnel(tc *tunnelContext) {
 	if err = setupSSHAgentForwarding(tc, sshClient, sess); err != nil {
 		return
 	}
-	runCommandInSSHTunnel(tc, sshClient)
+	runCommandInSSHTunnel(ctx, tc, sshClient)
 }
 
 func establishSSHSession(
+	ctx context.Context,
 	tc *tunnelContext,
 	sshClient *ssh.Client,
 ) (*ssh.Session, error) {
@@ -285,7 +314,7 @@ func establishSSHSession(
 
 	var session *ssh.Session
 	if err := wait.ExponentialBackoffWithContext(
-		tc.cancelCtx,
+		ctx,
 		backoff,
 		func(ctx context.Context) (bool, error) {
 			sess, err := sshClient.NewSession()
@@ -335,13 +364,13 @@ func setupSSHAgentForwarding(
 	return err
 }
 
-func runCommandInSSHTunnel(tc *tunnelContext, sshClient *ssh.Client) {
+func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ssh.Client) {
 	streamer := NewTunnelLogStreamer(tc.opts.Log)
 	defer func() { _ = streamer.Close() }()
 
 	tc.opts.Log.Debugf("running agent command in SSH tunnel: %q", tc.opts.Command)
 	if err := devssh.Run(devssh.RunOptions{
-		Context: tc.cancelCtx,
+		Context: ctx,
 		Client:  sshClient,
 		Command: tc.opts.Command,
 		Stdin:   tc.grpcPipes.stdinReader,
@@ -358,8 +387,6 @@ func runCommandInSSHTunnel(tc *tunnelContext, sshClient *ssh.Client) {
 		tc.errChan <- nil
 	}
 }
-
-const maxLogLines = 1
 
 type TunnelLogStreamer struct {
 	pw     *io.PipeWriter
@@ -452,4 +479,14 @@ func (l *TunnelLogStreamer) extractLogLevel(line string) (bool, logrus.Level) {
 	level, ok := logLevelMap[strings.ToLower(parts[1])]
 
 	return ok, level
+}
+
+func isCleanupEOF(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(err.Error()), "ssh session closed unexpectedly")
 }

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -19,12 +19,11 @@ import (
 	devsshagent "github.com/skevetter/devpod/pkg/ssh/agent"
 	"github.com/skevetter/log"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
-	// errorChannelBuffer is the size of the error channel buffer.
-	errorChannelBuffer = 2
 	// maxLogLines is the number of error lines to keep from tunnel output for debugging.
 	maxLogLines = 1
 )
@@ -54,8 +53,6 @@ type ExecuteCommandOptions struct {
 
 type tunnelContext struct {
 	opts      ExecuteCommandOptions
-	cancel    context.CancelFunc
-	errChan   chan error
 	sshPipes  *pipePair
 	grpcPipes *pipePair
 }
@@ -70,20 +67,22 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	}
 	opts.Log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
-	cancelCtx, tc, err := setupTunnelContext(ctx, opts)
+
+	tc, err := setupTunnelContext(opts)
 	if err != nil {
 		return nil, err
 	}
 	defer tc.cleanup()
 
-	var wg sync.WaitGroup
+	g, ctx := errgroup.WithContext(ctx)
+	var result *config2.Result
 
-	wg.Go(func() {
-		executeSSHServerHelper(cancelCtx, &sshServerHelperParams{
+	// Start SSH server helper
+	g.Go(func() error {
+		return executeSSHServerHelper(ctx, &sshServerHelperParams{
 			opts:         opts,
 			stdinReader:  tc.sshPipes.stdinReader,
 			stdoutWriter: tc.sshPipes.stdoutWriter,
-			errChan:      tc.errChan,
 		})
 	})
 
@@ -91,47 +90,44 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 		addPrivateKeys(ctx, opts)
 	}
 
-	wg.Go(func() {
-		runSSHTunnel(cancelCtx, tc)
+	// Start SSH tunnel
+	g.Go(func() error {
+		return runSSHTunnel(ctx, tc)
 	})
 
-	result, err := waitForTunnelCompletion(cancelCtx, tc)
-	wg.Wait() // Wait for goroutines to complete
+	// Run gRPC server
+	g.Go(func() error {
+		var err error
+		result, err = tc.opts.TunnelServerFunc(
+			ctx,
+			tc.grpcPipes.stdinWriter,
+			tc.grpcPipes.stdoutReader,
+		)
+		return err
+	})
 
-	errs := collectTunnelErrors(tc, result)
-	if err != nil {
-		errs = append(errs, err)
+	// Wait for all to complete
+	if err := g.Wait(); err != nil {
+		return result, err
 	}
 
-	if len(errs) == 0 {
-		return result, nil
-	}
-	return result, errors.Join(errs...)
+	return result, nil
 }
 
-func setupTunnelContext(
-	ctx context.Context,
-	opts ExecuteCommandOptions,
-) (context.Context, *tunnelContext, error) {
+func setupTunnelContext(opts ExecuteCommandOptions) (*tunnelContext, error) {
 	sshPipes, err := createPipes()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	cancelCtx, cancel := context.WithCancel(ctx)
-	errChan := make(chan error, errorChannelBuffer)
 
 	grpcPipes, err := createPipes()
 	if err != nil {
 		sshPipes.Close()
-		cancel()
-		return nil, nil, err
+		return nil, err
 	}
 
-	return cancelCtx, &tunnelContext{
+	return &tunnelContext{
 		opts:      opts,
-		cancel:    cancel,
-		errChan:   errChan,
 		sshPipes:  sshPipes,
 		grpcPipes: grpcPipes,
 	}, nil
@@ -140,59 +136,6 @@ func setupTunnelContext(
 func (tc *tunnelContext) cleanup() {
 	tc.sshPipes.Close()
 	tc.grpcPipes.Close()
-	tc.cancel()
-}
-
-func waitForTunnelCompletion(ctx context.Context, tc *tunnelContext) (*config2.Result, error) {
-	result, err := tc.opts.TunnelServerFunc(
-		ctx,
-		tc.grpcPipes.stdinWriter,
-		tc.grpcPipes.stdoutReader,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("start tunnel server: %w", err)
-	}
-
-	tc.opts.Log.Debug("awaiting tunnel server command completion")
-	return result, nil
-}
-
-// collectTunnelErrors collects errors from both goroutines running in the SSH tunnel.
-// It expects two errors:
-//   - First error: from executeSSHServerHelper (SSH server injection and agent command execution)
-//   - Second error: from runSSHTunnel (SSH tunnel establishment and command execution)
-//
-// If a valid result was received, EOF errors during cleanup are ignored as they indicate
-// normal session termination after successful completion.
-func collectTunnelErrors(tc *tunnelContext, result *config2.Result) []error {
-	hasValidResult := result != nil
-	var errs []error
-
-	err1 := <-tc.errChan
-	if shouldReportError(err1, hasValidResult, tc.opts.Log) {
-		errs = append(errs, err1)
-	}
-
-	err2 := <-tc.errChan
-	if shouldReportError(err2, hasValidResult, tc.opts.Log) {
-		errs = append(errs, err2)
-	}
-
-	return errs
-}
-
-// shouldReportError determines if an error should be reported to the caller.
-// It returns false for nil errors and for EOF errors that occur during cleanup
-// after a successful result has been received.
-func shouldReportError(err error, hasValidResult bool, log log.Logger) bool {
-	if err == nil {
-		return false
-	}
-	if hasValidResult && isCleanupEOF(err) {
-		log.Debug("ignoring EOF during cleanup after successful result")
-		return false
-	}
-	return true
 }
 
 type pipePair struct {
@@ -238,7 +181,6 @@ type sshServerHelperParams struct {
 	opts         ExecuteCommandOptions
 	stdinReader  *os.File
 	stdoutWriter *os.File
-	errChan      chan error
 }
 
 func isExpectedError(err error) bool {
@@ -254,7 +196,7 @@ func isExpectedError(err error) bool {
 	return false
 }
 
-func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) {
+func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) error {
 	defer p.opts.Log.Debug("done executing SSH server helper command")
 
 	writer := p.opts.Log.Writer(logrus.InfoLevel, false)
@@ -263,10 +205,9 @@ func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) {
 	p.opts.Log.Debugf("injecting and running SSH server command: %q", p.opts.SSHCommand)
 	err := p.opts.AgentInject(ctx, p.opts.SSHCommand, p.stdinReader, p.stdoutWriter, writer)
 	if err != nil && !isExpectedError(err) {
-		p.errChan <- fmt.Errorf("executing agent command: %w", err)
-	} else {
-		p.errChan <- nil
+		return fmt.Errorf("executing agent command: %w", err)
 	}
+	return nil
 }
 
 func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
@@ -277,12 +218,11 @@ func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
 	}
 }
 
-func runSSHTunnel(ctx context.Context, tc *tunnelContext) {
+func runSSHTunnel(ctx context.Context, tc *tunnelContext) error {
 	tc.opts.Log.Debug("creating SSH client")
 	sshClient, err := devssh.StdioClient(tc.sshPipes.stdoutReader, tc.sshPipes.stdinWriter, false)
 	if err != nil {
-		tc.errChan <- fmt.Errorf("failed to create SSH client: %w", err)
-		return
+		return fmt.Errorf("failed to create SSH client: %w", err)
 	}
 	tc.opts.Log.Debug("SSH client created")
 	defer func() {
@@ -292,7 +232,7 @@ func runSSHTunnel(ctx context.Context, tc *tunnelContext) {
 
 	sess, err := establishSSHSession(ctx, tc, sshClient)
 	if err != nil {
-		return
+		return err
 	}
 	defer func() {
 		_ = sess.Close()
@@ -300,9 +240,9 @@ func runSSHTunnel(ctx context.Context, tc *tunnelContext) {
 	}()
 
 	if err = setupSSHAgentForwarding(tc, sshClient, sess); err != nil {
-		return
+		return err
 	}
-	runCommandInSSHTunnel(ctx, tc, sshClient)
+	return runCommandInSSHTunnel(ctx, tc, sshClient)
 }
 
 func establishSSHSession(
@@ -332,14 +272,7 @@ func establishSSHSession(
 			return true, nil // Success
 		},
 	); err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			tc.errChan <- err
-			return nil, err
-		}
-		// Timeout from backoff
-		timeoutErr := fmt.Errorf("SSH server timeout: %w", err)
-		tc.errChan <- timeoutErr
-		return nil, timeoutErr
+		return nil, fmt.Errorf("SSH server timeout: %w", err)
 	}
 
 	return session, nil
@@ -364,12 +297,12 @@ func setupSSHAgentForwarding(
 
 	if err != nil {
 		tc.opts.Log.Warnf("SSH agent forwarding failed: %v", err)
-		tc.errChan <- fmt.Errorf("forward agent: %w", err)
+		return fmt.Errorf("forward agent: %w", err)
 	}
-	return err
+	return nil
 }
 
-func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ssh.Client) {
+func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ssh.Client) error {
 	streamer := NewTunnelLogStreamer(tc.opts.Log)
 	defer func() { _ = streamer.Close() }()
 
@@ -384,13 +317,11 @@ func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ss
 	}); err != nil {
 		_ = streamer.Close()
 		if out := streamer.ErrorOutput(); out != "" {
-			tc.errChan <- fmt.Errorf("run agent command failed: %w\n%s", err, out)
-		} else {
-			tc.errChan <- fmt.Errorf("run agent command failed: %w", err)
+			return fmt.Errorf("run agent command failed: %w\n%s", err, out)
 		}
-	} else {
-		tc.errChan <- nil
+		return fmt.Errorf("run agent command failed: %w", err)
 	}
+	return nil
 }
 
 type TunnelLogStreamer struct {
@@ -484,14 +415,4 @@ func (l *TunnelLogStreamer) extractLogLevel(line string) (bool, logrus.Level) {
 	level, ok := logLevelMap[strings.ToLower(parts[1])]
 
 	return ok, level
-}
-
-func isCleanupEOF(err error) bool {
-	for e := err; e != nil; e = errors.Unwrap(e) {
-		if errors.Is(e, io.EOF) ||
-			strings.Contains(strings.ToLower(e.Error()), "ssh session closed unexpectedly") {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -19,6 +19,7 @@ import (
 	devsshagent "github.com/skevetter/devpod/pkg/ssh/agent"
 	"github.com/skevetter/log"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -64,38 +65,39 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	}
 	defer tc.cleanup()
 
-	// Inject SSH server helper
-	if err := executeSSHServerHelper(cancelCtx, &sshServerHelperParams{
-		opts:         opts,
-		stdinReader:  tc.sshPipes.stdinReader,
-		stdoutWriter: tc.sshPipes.stdoutWriter,
-	}); err != nil {
-		return nil, err
-	}
-
 	if opts.AddPrivateKeys {
 		addPrivateKeys(ctx, opts)
 	}
 
-	// Run SSH tunnel
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- runSSHTunnel(cancelCtx, tc)
-	}()
+	g := new(errgroup.Group)
+	var result *config2.Result
 
-	// Run gRPC server
-	result, err := tc.opts.TunnelServerFunc(
-		cancelCtx,
-		tc.grpcPipes.stdinWriter,
-		tc.grpcPipes.stdoutReader,
-	)
+	// SSH server helper
+	g.Go(func() error {
+		return executeSSHServerHelper(cancelCtx, &sshServerHelperParams{
+			opts:         opts,
+			stdinReader:  tc.sshPipes.stdinReader,
+			stdoutWriter: tc.sshPipes.stdoutWriter,
+		})
+	})
 
-	// Wait for SSH tunnel to finish
-	if tunnelErr := <-errChan; tunnelErr != nil && err == nil {
-		err = tunnelErr
-	}
+	// SSH tunnel
+	g.Go(func() error {
+		return runSSHTunnel(cancelCtx, tc)
+	})
 
-	return result, err
+	// gRPC server
+	g.Go(func() error {
+		var err error
+		result, err = tc.opts.TunnelServerFunc(
+			cancelCtx,
+			tc.grpcPipes.stdinWriter,
+			tc.grpcPipes.stdoutReader,
+		)
+		return err
+	})
+
+	return result, g.Wait()
 }
 
 func setupTunnelContext(

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -19,13 +19,7 @@ import (
 	devsshagent "github.com/skevetter/devpod/pkg/ssh/agent"
 	"github.com/skevetter/log"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/wait"
-)
-
-const (
-	// maxLogLines is the number of error lines to keep from tunnel output for debugging.
-	maxLogLines = 1
 )
 
 type (
@@ -53,81 +47,79 @@ type ExecuteCommandOptions struct {
 
 type tunnelContext struct {
 	opts      ExecuteCommandOptions
+	cancelCtx context.Context
+	cancel    context.CancelFunc
 	sshPipes  *pipePair
 	grpcPipes *pipePair
 }
 
 // ExecuteCommand runs the command in an SSH Tunnel and returns the result.
 func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.Result, error) {
-	if opts.TunnelServerFunc == nil {
-		return nil, errors.New("tunnel server func is required")
-	}
-	if opts.AgentInject == nil {
-		return nil, errors.New("agent inject func is required")
-	}
 	opts.Log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
 
-	tc, err := setupTunnelContext(opts)
+	cancelCtx, tc, err := setupTunnelContext(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 	defer tc.cleanup()
 
-	g, ctx := errgroup.WithContext(ctx)
-	var result *config2.Result
-
-	// Start SSH server helper
-	g.Go(func() error {
-		return executeSSHServerHelper(ctx, &sshServerHelperParams{
-			opts:         opts,
-			stdinReader:  tc.sshPipes.stdinReader,
-			stdoutWriter: tc.sshPipes.stdoutWriter,
-		})
-	})
+	// Inject SSH server helper
+	if err := executeSSHServerHelper(cancelCtx, &sshServerHelperParams{
+		opts:         opts,
+		stdinReader:  tc.sshPipes.stdinReader,
+		stdoutWriter: tc.sshPipes.stdoutWriter,
+	}); err != nil {
+		return nil, err
+	}
 
 	if opts.AddPrivateKeys {
 		addPrivateKeys(ctx, opts)
 	}
 
-	// Start SSH tunnel
-	g.Go(func() error {
-		return runSSHTunnel(ctx, tc)
-	})
+	// Run SSH tunnel
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- runSSHTunnel(cancelCtx, tc)
+	}()
 
 	// Run gRPC server
-	g.Go(func() error {
-		var err error
-		result, err = tc.opts.TunnelServerFunc(
-			ctx,
-			tc.grpcPipes.stdinWriter,
-			tc.grpcPipes.stdoutReader,
-		)
-		return err
-	})
+	result, err := tc.opts.TunnelServerFunc(
+		cancelCtx,
+		tc.grpcPipes.stdinWriter,
+		tc.grpcPipes.stdoutReader,
+	)
 
-	// Wait for all to complete
-	if err := g.Wait(); err != nil {
-		return result, err
+	// Wait for SSH tunnel to finish
+	if tunnelErr := <-errChan; tunnelErr != nil && err == nil {
+		err = tunnelErr
 	}
 
-	return result, nil
+	return result, err
 }
 
-func setupTunnelContext(opts ExecuteCommandOptions) (*tunnelContext, error) {
+func setupTunnelContext(
+	ctx context.Context,
+	opts ExecuteCommandOptions,
+) (context.Context, *tunnelContext, error) {
 	sshPipes, err := createPipes()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	cancelCtx, cancel := context.WithCancel(ctx)
 
 	grpcPipes, err := createPipes()
 	if err != nil {
 		sshPipes.Close()
-		return nil, err
+		cancel()
+		return nil, nil, err
 	}
 
-	return &tunnelContext{
+	return cancelCtx, &tunnelContext{
 		opts:      opts,
+		cancelCtx: cancelCtx,
+		cancel:    cancel,
 		sshPipes:  sshPipes,
 		grpcPipes: grpcPipes,
 	}, nil
@@ -136,6 +128,7 @@ func setupTunnelContext(opts ExecuteCommandOptions) (*tunnelContext, error) {
 func (tc *tunnelContext) cleanup() {
 	tc.sshPipes.Close()
 	tc.grpcPipes.Close()
+	tc.cancel()
 }
 
 type pipePair struct {
@@ -323,6 +316,8 @@ func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ss
 	}
 	return nil
 }
+
+const maxLogLines = 1
 
 type TunnelLogStreamer struct {
 	pw     *io.PipeWriter

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -96,10 +96,6 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	})
 
 	result, err := waitForTunnelCompletion(cancelCtx, tc)
-	if err != nil {
-		opts.Log.Warnf("tunnel server error: %v", err)
-		tc.cancel() // stop other goroutine if tunnel server failed
-	}
 	wg.Wait() // Wait for goroutines to complete
 
 	return result, err

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -19,7 +19,6 @@ import (
 	devsshagent "github.com/skevetter/devpod/pkg/ssh/agent"
 	"github.com/skevetter/log"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -50,6 +49,7 @@ type tunnelContext struct {
 	opts      ExecuteCommandOptions
 	cancelCtx context.Context
 	cancel    context.CancelFunc
+	errChan   chan error
 	sshPipes  *pipePair
 	grpcPipes *pipePair
 }
@@ -59,69 +59,61 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	opts.Log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
 
-	cancelCtx, tc, err := setupTunnelContext(ctx, opts)
+	tc, err := setupTunnelContext(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 	defer tc.cleanup()
 
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		executeSSHServerHelper(tc.cancelCtx, &sshServerHelperParams{
+			opts:         opts,
+			cancel:       tc.cancel,
+			stdinReader:  tc.sshPipes.stdinReader,
+			stdoutWriter: tc.sshPipes.stdoutWriter,
+			errChan:      tc.errChan,
+		})
+	})
+
 	if opts.AddPrivateKeys {
 		addPrivateKeys(ctx, opts)
 	}
 
-	g := new(errgroup.Group)
-	var result *config2.Result
-
-	// SSH server helper
-	g.Go(func() error {
-		return executeSSHServerHelper(cancelCtx, &sshServerHelperParams{
-			opts:         opts,
-			stdinReader:  tc.sshPipes.stdinReader,
-			stdoutWriter: tc.sshPipes.stdoutWriter,
-		})
+	wg.Go(func() {
+		runSSHTunnel(tc)
 	})
 
-	// SSH tunnel
-	g.Go(func() error {
-		return runSSHTunnel(cancelCtx, tc)
-	})
+	result, err := waitForTunnelCompletion(tc)
 
-	// gRPC server
-	g.Go(func() error {
-		var err error
-		result, err = tc.opts.TunnelServerFunc(
-			cancelCtx,
-			tc.grpcPipes.stdinWriter,
-			tc.grpcPipes.stdoutReader,
-		)
-		return err
-	})
+	// Wait for goroutines to complete
+	wg.Wait()
 
-	return result, g.Wait()
+	return result, err
 }
 
-func setupTunnelContext(
-	ctx context.Context,
-	opts ExecuteCommandOptions,
-) (context.Context, *tunnelContext, error) {
+func setupTunnelContext(ctx context.Context, opts ExecuteCommandOptions) (*tunnelContext, error) {
 	sshPipes, err := createPipes()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	cancelCtx, cancel := context.WithCancel(ctx)
+	errChan := make(chan error, 2)
 
 	grpcPipes, err := createPipes()
 	if err != nil {
 		sshPipes.Close()
 		cancel()
-		return nil, nil, err
+		return nil, err
 	}
 
-	return cancelCtx, &tunnelContext{
+	return &tunnelContext{
 		opts:      opts,
 		cancelCtx: cancelCtx,
 		cancel:    cancel,
+		errChan:   errChan,
 		sshPipes:  sshPipes,
 		grpcPipes: grpcPipes,
 	}, nil
@@ -131,6 +123,38 @@ func (tc *tunnelContext) cleanup() {
 	tc.sshPipes.Close()
 	tc.grpcPipes.Close()
 	tc.cancel()
+}
+
+func waitForTunnelCompletion(tc *tunnelContext) (*config2.Result, error) {
+	result, err := tc.opts.TunnelServerFunc(
+		tc.cancelCtx,
+		tc.grpcPipes.stdinWriter,
+		tc.grpcPipes.stdoutReader,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("start tunnel server: %w", err)
+	}
+
+	tc.opts.Log.Debug("awaiting tunnel server command completion")
+
+	// Collect both errors to handle race condition
+	var errs []error
+	err1 := <-tc.errChan
+	if err1 != nil {
+		errs = append(errs, err1)
+	}
+	err2 := <-tc.errChan
+	if err2 != nil {
+		errs = append(errs, err2)
+	}
+
+	tc.opts.Log.Debug("SSH tunnel execution completed")
+
+	// Return first error or combine multiple errors
+	if len(errs) == 0 {
+		return result, nil
+	}
+	return result, errors.Join(errs...)
 }
 
 type pipePair struct {
@@ -174,8 +198,10 @@ func createPipes() (*pipePair, error) {
 
 type sshServerHelperParams struct {
 	opts         ExecuteCommandOptions
+	cancel       context.CancelFunc
 	stdinReader  *os.File
 	stdoutWriter *os.File
+	errChan      chan error
 }
 
 func isExpectedError(err error) bool {
@@ -191,8 +217,9 @@ func isExpectedError(err error) bool {
 	return false
 }
 
-func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) error {
+func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) {
 	defer p.opts.Log.Debug("done executing SSH server helper command")
+	defer p.cancel()
 
 	writer := p.opts.Log.Writer(logrus.InfoLevel, false)
 	defer func() { _ = writer.Close() }()
@@ -200,9 +227,10 @@ func executeSSHServerHelper(ctx context.Context, p *sshServerHelperParams) error
 	p.opts.Log.Debugf("injecting and running SSH server command: %q", p.opts.SSHCommand)
 	err := p.opts.AgentInject(ctx, p.opts.SSHCommand, p.stdinReader, p.stdoutWriter, writer)
 	if err != nil && !isExpectedError(err) {
-		return fmt.Errorf("executing agent command: %w", err)
+		p.errChan <- fmt.Errorf("executing agent command: %w", err)
+	} else {
+		p.errChan <- nil
 	}
-	return nil
 }
 
 func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
@@ -213,11 +241,14 @@ func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
 	}
 }
 
-func runSSHTunnel(ctx context.Context, tc *tunnelContext) error {
+func runSSHTunnel(tc *tunnelContext) {
+	defer tc.cancel()
+
 	tc.opts.Log.Debug("creating SSH client")
 	sshClient, err := devssh.StdioClient(tc.sshPipes.stdoutReader, tc.sshPipes.stdinWriter, false)
 	if err != nil {
-		return fmt.Errorf("failed to create SSH client: %w", err)
+		tc.errChan <- fmt.Errorf("failed to create SSH client: %w", err)
+		return
 	}
 	tc.opts.Log.Debug("SSH client created")
 	defer func() {
@@ -225,9 +256,9 @@ func runSSHTunnel(ctx context.Context, tc *tunnelContext) error {
 		tc.opts.Log.Debug("SSH client closed")
 	}()
 
-	sess, err := establishSSHSession(ctx, tc, sshClient)
+	sess, err := establishSSHSession(tc, sshClient)
 	if err != nil {
-		return err
+		return
 	}
 	defer func() {
 		_ = sess.Close()
@@ -235,13 +266,12 @@ func runSSHTunnel(ctx context.Context, tc *tunnelContext) error {
 	}()
 
 	if err = setupSSHAgentForwarding(tc, sshClient, sess); err != nil {
-		return err
+		return
 	}
-	return runCommandInSSHTunnel(ctx, tc, sshClient)
+	runCommandInSSHTunnel(tc, sshClient)
 }
 
 func establishSSHSession(
-	ctx context.Context,
 	tc *tunnelContext,
 	sshClient *ssh.Client,
 ) (*ssh.Session, error) {
@@ -254,7 +284,7 @@ func establishSSHSession(
 
 	var session *ssh.Session
 	if err := wait.ExponentialBackoffWithContext(
-		ctx,
+		tc.cancelCtx,
 		backoff,
 		func(ctx context.Context) (bool, error) {
 			sess, err := sshClient.NewSession()
@@ -267,7 +297,14 @@ func establishSSHSession(
 			return true, nil // Success
 		},
 	); err != nil {
-		return nil, fmt.Errorf("SSH server timeout: %w", err)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			tc.errChan <- err
+			return nil, err
+		}
+		// Timeout from backoff
+		timeoutErr := fmt.Errorf("SSH server timeout: %w", err)
+		tc.errChan <- timeoutErr
+		return nil, timeoutErr
 	}
 
 	return session, nil
@@ -292,18 +329,18 @@ func setupSSHAgentForwarding(
 
 	if err != nil {
 		tc.opts.Log.Warnf("SSH agent forwarding failed: %v", err)
-		return fmt.Errorf("forward agent: %w", err)
+		tc.errChan <- fmt.Errorf("forward agent: %w", err)
 	}
-	return nil
+	return err
 }
 
-func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ssh.Client) error {
+func runCommandInSSHTunnel(tc *tunnelContext, sshClient *ssh.Client) {
 	streamer := NewTunnelLogStreamer(tc.opts.Log)
 	defer func() { _ = streamer.Close() }()
 
 	tc.opts.Log.Debugf("running agent command in SSH tunnel: %q", tc.opts.Command)
 	if err := devssh.Run(devssh.RunOptions{
-		Context: ctx,
+		Context: tc.cancelCtx,
 		Client:  sshClient,
 		Command: tc.opts.Command,
 		Stdin:   tc.grpcPipes.stdinReader,
@@ -312,11 +349,13 @@ func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ss
 	}); err != nil {
 		_ = streamer.Close()
 		if out := streamer.ErrorOutput(); out != "" {
-			return fmt.Errorf("run agent command failed: %w\n%s", err, out)
+			tc.errChan <- fmt.Errorf("run agent command failed: %w\n%s", err, out)
+		} else {
+			tc.errChan <- fmt.Errorf("run agent command failed: %w", err)
 		}
-		return fmt.Errorf("run agent command failed: %w", err)
+	} else {
+		tc.errChan <- nil
 	}
-	return nil
 }
 
 const maxLogLines = 1

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -62,9 +62,14 @@ type tunnelContext struct {
 
 // ExecuteCommand runs the command in an SSH Tunnel and returns the result.
 func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.Result, error) {
+	if opts.TunnelServerFunc == nil {
+		return nil, errors.New("tunnel server func is required")
+	}
+	if opts.AgentInject == nil {
+		return nil, errors.New("agent inject func is required")
+	}
 	opts.Log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
-
 	cancelCtx, tc, err := setupTunnelContext(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -486,11 +491,11 @@ func (l *TunnelLogStreamer) extractLogLevel(line string) (bool, logrus.Level) {
 }
 
 func isCleanupEOF(err error) bool {
-	if err == nil {
-		return false
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if errors.Is(e, io.EOF) ||
+			strings.Contains(strings.ToLower(e.Error()), "ssh session closed unexpectedly") {
+			return true
+		}
 	}
-	if errors.Is(err, io.EOF) {
-		return true
-	}
-	return strings.Contains(strings.ToLower(err.Error()), "ssh session closed unexpectedly")
+	return false
 }

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -47,8 +47,6 @@ type ExecuteCommandOptions struct {
 
 type tunnelContext struct {
 	opts      ExecuteCommandOptions
-	cancelCtx context.Context
-	cancel    context.CancelFunc
 	errChan   chan error
 	sshPipes  *pipePair
 	grpcPipes *pipePair
@@ -59,7 +57,7 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	opts.Log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
 
-	tc, err := setupTunnelContext(ctx, opts)
+	tc, err := setupTunnelContext(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -68,9 +66,8 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		executeSSHServerHelper(tc.cancelCtx, &sshServerHelperParams{
+		executeSSHServerHelper(ctx, &sshServerHelperParams{
 			opts:         opts,
-			cancel:       tc.cancel,
 			stdinReader:  tc.sshPipes.stdinReader,
 			stdoutWriter: tc.sshPipes.stdoutWriter,
 			errChan:      tc.errChan,
@@ -82,10 +79,10 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	}
 
 	wg.Go(func() {
-		runSSHTunnel(tc)
+		runSSHTunnel(ctx, tc)
 	})
 
-	result, err := waitForTunnelCompletion(tc)
+	result, err := waitForTunnelCompletion(ctx, tc)
 
 	// Wait for goroutines to complete
 	wg.Wait()
@@ -93,26 +90,22 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	return result, err
 }
 
-func setupTunnelContext(ctx context.Context, opts ExecuteCommandOptions) (*tunnelContext, error) {
+func setupTunnelContext(opts ExecuteCommandOptions) (*tunnelContext, error) {
 	sshPipes, err := createPipes()
 	if err != nil {
 		return nil, err
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
 	errChan := make(chan error, 2)
 
 	grpcPipes, err := createPipes()
 	if err != nil {
 		sshPipes.Close()
-		cancel()
 		return nil, err
 	}
 
 	return &tunnelContext{
 		opts:      opts,
-		cancelCtx: cancelCtx,
-		cancel:    cancel,
 		errChan:   errChan,
 		sshPipes:  sshPipes,
 		grpcPipes: grpcPipes,
@@ -122,12 +115,11 @@ func setupTunnelContext(ctx context.Context, opts ExecuteCommandOptions) (*tunne
 func (tc *tunnelContext) cleanup() {
 	tc.sshPipes.Close()
 	tc.grpcPipes.Close()
-	tc.cancel()
 }
 
-func waitForTunnelCompletion(tc *tunnelContext) (*config2.Result, error) {
+func waitForTunnelCompletion(ctx context.Context, tc *tunnelContext) (*config2.Result, error) {
 	result, err := tc.opts.TunnelServerFunc(
-		tc.cancelCtx,
+		ctx,
 		tc.grpcPipes.stdinWriter,
 		tc.grpcPipes.stdoutReader,
 	)
@@ -241,9 +233,7 @@ func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
 	}
 }
 
-func runSSHTunnel(tc *tunnelContext) {
-	defer tc.cancel()
-
+func runSSHTunnel(ctx context.Context, tc *tunnelContext) {
 	tc.opts.Log.Debug("creating SSH client")
 	sshClient, err := devssh.StdioClient(tc.sshPipes.stdoutReader, tc.sshPipes.stdinWriter, false)
 	if err != nil {
@@ -256,7 +246,7 @@ func runSSHTunnel(tc *tunnelContext) {
 		tc.opts.Log.Debug("SSH client closed")
 	}()
 
-	sess, err := establishSSHSession(tc, sshClient)
+	sess, err := establishSSHSession(ctx, tc, sshClient)
 	if err != nil {
 		return
 	}
@@ -268,10 +258,11 @@ func runSSHTunnel(tc *tunnelContext) {
 	if err = setupSSHAgentForwarding(tc, sshClient, sess); err != nil {
 		return
 	}
-	runCommandInSSHTunnel(tc, sshClient)
+	runCommandInSSHTunnel(ctx, tc, sshClient)
 }
 
 func establishSSHSession(
+	ctx context.Context,
 	tc *tunnelContext,
 	sshClient *ssh.Client,
 ) (*ssh.Session, error) {
@@ -284,7 +275,7 @@ func establishSSHSession(
 
 	var session *ssh.Session
 	if err := wait.ExponentialBackoffWithContext(
-		tc.cancelCtx,
+		ctx,
 		backoff,
 		func(ctx context.Context) (bool, error) {
 			sess, err := sshClient.NewSession()
@@ -334,13 +325,13 @@ func setupSSHAgentForwarding(
 	return err
 }
 
-func runCommandInSSHTunnel(tc *tunnelContext, sshClient *ssh.Client) {
+func runCommandInSSHTunnel(ctx context.Context, tc *tunnelContext, sshClient *ssh.Client) {
 	streamer := NewTunnelLogStreamer(tc.opts.Log)
 	defer func() { _ = streamer.Close() }()
 
 	tc.opts.Log.Debugf("running agent command in SSH tunnel: %q", tc.opts.Command)
 	if err := devssh.Run(devssh.RunOptions{
-		Context: tc.cancelCtx,
+		Context: ctx,
 		Client:  sshClient,
 		Command: tc.opts.Command,
 		Stdin:   tc.grpcPipes.stdinReader,

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -91,6 +91,10 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	})
 
 	result, err := waitForTunnelCompletion(cancelCtx, tc)
+	if err != nil {
+		opts.Log.Warnf("tunnel server error: %v", err)
+		tc.cancel() // stop other goroutine if tunnel server failed
+	}
 	wg.Wait() // Wait for goroutines to complete
 
 	return result, err
@@ -488,5 +492,5 @@ func isCleanupEOF(err error) bool {
 	if errors.Is(err, io.EOF) {
 		return true
 	}
-	return strings.HasPrefix(strings.ToLower(err.Error()), "ssh session closed unexpectedly")
+	return strings.Contains(strings.ToLower(err.Error()), "ssh session closed unexpectedly")
 }

--- a/pkg/ssh/server/exec.go
+++ b/pkg/ssh/server/exec.go
@@ -8,15 +8,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/skevetter/log"
 	"github.com/skevetter/ssh"
 )
 
 func execNonPTY(sess ssh.Session, cmd *exec.Cmd, log log.Logger) (err error) {
-	log.WithFields(logrus.Fields{
-		"command": strings.Join(cmd.Args, " "),
-	}).Debug("execute SSH server command")
+	log.Debugf("execute SSH server command: %s", strings.Join(cmd.Args, " "))
 	// init pipes
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -77,7 +74,7 @@ func execPTY(
 	cmd *exec.Cmd,
 	log log.Logger,
 ) (err error) {
-	log.Debugf("Execute SSH server PTY command: %s", strings.Join(cmd.Args, " "))
+	log.Debugf("execute SSH server PTY command: %s", strings.Join(cmd.Args, " "))
 
 	cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", ptyReq.Term))
 	f, err := startPTY(cmd)


### PR DESCRIPTION
- **refactor: ssh tunnels and context handling for EOF errors in Windows e2e tests**
- **refactor(devcontainer/sshtunnel):error and context handling for EOF errors in Windows e2e tests**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Commands now reliably honor external cancellation and timeouts, improving interrupt behavior and reducing spurious errors during tunnel setup, execution, and teardown.
  * Integration API for executing SSH/tunnel commands was adjusted; callers should pass context in the new form when invoking these operations.

* **Style**
  * SSH server log messages simplified and standardized for clearer, less noisy output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->