### PR TITLE
fix(upgrade): trim 'v' prefix from current version check in Upgrade function

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/skevetter/devpod/pkg/version"
@@ -20,7 +21,7 @@ func Upgrade(ctx context.Context, targetVersion string, dryRun bool, logger log.
 		return err
 	}
 
-	if release.Version() == version.GetVersion() {
+	if release.Version() == strings.TrimLeft(version.GetVersion(), "v") {
 		if _, err := fmt.Fprintf(
 			os.Stdout,
 			"devpod version %s is already up-to-date\n",


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version comparison logic in upgrade detection to consistently handle version strings with and without leading 'v' prefix, ensuring accurate up-to-date status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->