### PR TITLE
fix: extend timeout when getting Docker credentials from host

### DIFF
--- a/pkg/dockercredentials/helper.go
+++ b/pkg/dockercredentials/helper.go
@@ -14,7 +14,12 @@ import (
 )
 
 const (
-	credentialsTimeout = 5 * time.Second
+	// Obtaining credentials might require human interaction, e.g., to log in
+	// using an OAuth flow. Use a sufficiently long timeout to allow for that.
+	// (The credential request is forwarded to the host, where the credentials
+	// are either obtained from a Docker configuration file, or obtained from
+	// a credential helper on the host -- the latter can take a while.)
+	credentialsTimeout = 10 * time.Minute
 	logFileName        = "credential-helper.log"
 )
 


### PR DESCRIPTION
The Docker credential helper in the agent forwards its requests to the
host. There, the credentials are either taken from a configuration file
or keystore, which is quite fast. Or they are obtained from another
Docker credential helper. Some credential helpers prompt the user to
log in to a registry using a single-sign-on or web flow.

Use a sufficiently large timeout to let a human interact with a login
system; I went for 10 minutes to give users time to also find the right
password, unlock their password manager, and what else might be needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Extended the timeout for Docker credential retrieval operations from 5 seconds to 10 minutes, providing more time for credential resolution processes to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->