### PR TITLE
fix(ssh/server): start PTY with the client terminal dimensions

### DIFF
--- a/pkg/ssh/server/exec.go
+++ b/pkg/ssh/server/exec.go
@@ -8,15 +8,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/skevetter/log"
 	"github.com/skevetter/ssh"
 )
 
 func execNonPTY(sess ssh.Session, cmd *exec.Cmd, log log.Logger) (err error) {
-	log.WithFields(logrus.Fields{
-		"command": strings.Join(cmd.Args, " "),
-	}).Debug("execute SSH server command")
+	log.Debugf("execute SSH server command: %s", strings.Join(cmd.Args, " "))
 	// init pipes
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -77,10 +74,19 @@ func execPTY(
 	cmd *exec.Cmd,
 	log log.Logger,
 ) (err error) {
-	log.Debugf("Execute SSH server PTY command: %s", strings.Join(cmd.Args, " "))
-
+	log.Debugf("execute SSH server PTY command: %s", strings.Join(cmd.Args, " "))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", ptyReq.Term))
-	f, err := startPTY(cmd)
+	// Start the PTY with the client's terminal dimensions. pty.Start
+	// (without size) creates the PTY with OS defaults (typically 80x24) which
+	// causes rendering corruption in TUI programs (e.g. Neovim split buffers).
+	//
+	// Similar PTY solutions used in other Go projects:
+	//   - coder/wsep:           https://github.com/coder/wsep/blob/master/localexec_unix.go#L64
+	//   - wavetermdev/waveterm: https://github.com/wavetermdev/waveterm/blob/main/pkg/shellexec/shellexec.go#L168
+	//   - jumpserver/koko:      https://github.com/jumpserver/koko/blob/dev/pkg/localcommand/local_command.go#L49
+	//   - daytonaio/daytona:
+	//       https://github.com/daytonaio/daytona/blob/main/apps/daemon/pkg/toolbox/process/pty/session.go#L61
+	f, err := startPTY(cmd, ptyReq.Window.Width, ptyReq.Window.Height)
 	if err != nil {
 		return fmt.Errorf("start pty: %w", err)
 	}

--- a/pkg/ssh/server/pty_supported.go
+++ b/pkg/ssh/server/pty_supported.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"math"
 	"os"
 	"os/exec"
 	"syscall"
@@ -11,11 +12,22 @@ import (
 	"github.com/creack/pty"
 )
 
-func startPTY(cmd *exec.Cmd) (*os.File, error) {
-	return pty.Start(cmd)
+func startPTY(cmd *exec.Cmd, w, h int) (*os.File, error) {
+	return pty.StartWithSize(cmd, &pty.Winsize{Cols: clampUint16(w), Rows: clampUint16(h)})
+}
+
+func clampUint16(v int) uint16 {
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxUint16 {
+		return math.MaxUint16
+	}
+	return uint16(v) //#nosec G115
 }
 
 func setWinSize(f *os.File, w, h int) {
+	ws := struct{ h, w, x, y uint16 }{clampUint16(h), clampUint16(w), 0, 0}
 	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(syscall.TIOCSWINSZ),
-		uintptr(unsafe.Pointer(&struct{ h, w, x, y uint16 }{uint16(h), uint16(w), 0, 0})))
+		uintptr(unsafe.Pointer(&ws))) //#nosec G103 -- required for TIOCSWINSZ ioctl
 }

--- a/pkg/ssh/server/pty_unsupported.go
+++ b/pkg/ssh/server/pty_unsupported.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 )
 
-func startPTY(cmd *exec.Cmd) (*os.File, error) {
+func startPTY(cmd *exec.Cmd, w, h int) (*os.File, error) {
 	return nil, fmt.Errorf("pty is currently not supported on windows")
 }
 


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * SSH PTY connections now correctly use the client's terminal window dimensions, resolving rendering issues in terminal user interface applications.

* **Refactor**
  * Simplified internal logging implementation by removing unnecessary dependencies and standardizing log calls.
  * Enhanced PTY initialization with proper window size validation across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->