### PR TITLE
fix(ssh/server): disable PTY emulation to prevent terminal rendering issues in TUI programs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/ramr/go-reaper v0.3.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/skevetter/log v0.0.0-20260106023547-bfd26ab1367c
-	github.com/skevetter/ssh v0.0.8
+	github.com/skevetter/ssh v0.1.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -656,8 +656,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skevetter/log v0.0.0-20260106023547-bfd26ab1367c h1:2IjLo9V6TLV2rORRKKu+NVMSrOAEeuS4KJPk3v9e1rs=
 github.com/skevetter/log v0.0.0-20260106023547-bfd26ab1367c/go.mod h1:Aqjwx8xRSxBWtTYXK3EzxManSgYZl7FaSh8J5LvTAK0=
-github.com/skevetter/ssh v0.0.8 h1:YH9ENxRgfA3wGogxzBx16gQbSiR39sqCx36t8wLnQlw=
-github.com/skevetter/ssh v0.0.8/go.mod h1:Kwjgc5zB58WGC40nP1rBQIPYoNnhkAwmkf/OvErc0ow=
+github.com/skevetter/ssh v0.1.0 h1:+Kcb77Z8WHc+uiHVF9JJCMZjdFiY+o/Tn2Pz7pGyIDs=
+github.com/skevetter/ssh v0.1.0/go.mod h1:Kwjgc5zB58WGC40nP1rBQIPYoNnhkAwmkf/OvErc0ow=
 github.com/skevetter/tailscale v1.92.2 h1:9P3GFPhZJpnoHzgwk86kK1fNNB8ibOIgkkHqt3ARaRM=
 github.com/skevetter/tailscale v1.92.2/go.mod h1:dYlHLLo1QUXtOCpXiIe8fdkZVAcQZFnjfwTdXI25fDc=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=

--- a/pkg/ssh/server/exec.go
+++ b/pkg/ssh/server/exec.go
@@ -74,13 +74,29 @@ func execPTY(
 	cmd *exec.Cmd,
 	log log.Logger,
 ) (err error) {
+	// Disable the gliderlabs/ssh minimal PTY emulation (NL→CRNL conversion
+	// in session.Write). When a real PTY is allocated, the kernel's line
+	// discipline already performs NL→CRNL translation on output. The
+	// gliderlabs/ssh library doesn't know this and applies its own conversion,
+	// resulting in double translation (\n → \r\r\n) that corrupts terminal
+	// escape sequences.
+	//
+	// This manifests as rendering corruption in full-screen TUI programs
+	// (e.g. Neovim split windows, tmux panes) when connected via DevPod SSH,
+	// while docker exec -it and direct SSH work fine because they bypass
+	// gliderlabs/ssh entirely.
+	//
+	// The fix was ported from coder/ssh (Coder's fork of gliderlabs/ssh):
+	//   - Coder issue:  https://github.com/coder/coder/issues/3371
+	//   - Neovim issue: https://github.com/neovim/neovim/issues/3875
+	sess.DisablePTYEmulation()
 	log.Debugf("execute SSH server PTY command: %s", strings.Join(cmd.Args, " "))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", ptyReq.Term))
 	// Start the PTY with the client's terminal dimensions. pty.Start
 	// (without size) creates the PTY with OS defaults (typically 80x24) which
 	// causes rendering corruption in TUI programs (e.g. Neovim split buffers).
 	//
-	// Similar PTY solutions used in other Go projects:
+	// Similar PTY solutions used in other projects:
 	//   - coder/wsep:           https://github.com/coder/wsep/blob/master/localexec_unix.go#L64
 	//   - wavetermdev/waveterm: https://github.com/wavetermdev/waveterm/blob/main/pkg/shellexec/shellexec.go#L168
 	//   - jumpserver/koko:      https://github.com/jumpserver/koko/blob/dev/pkg/localcommand/local_command.go#L49


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed terminal escape sequence corruption in full-screen terminal user interface (TUI) programs by correcting PTY newline handling to prevent double character conversion.

## Chores
* Updated SSH dependency to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->