### PR TITLE
Fix and refactor extension installation in VS Code flavors

### DIFF
--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -50,14 +50,20 @@ type flavorConfig struct {
 	binName     string
 }
 
+// Map of VS Code flavors. The correct configuration options can be found in
+// `resources/app/product.json` of the VS Code fork.
+//
+// - Display name
+// - Server directory, matching serverDataFolderName in `product.json`.
+// - Server binary name, matching serverApplicationName in `product.json`.
 var flavorConfigs = map[Flavor]flavorConfig{
 	FlavorStable:      {"VS Code", ".vscode-server", "code-server"},
 	FlavorInsiders:    {"VS Code Insiders", ".vscode-server-insiders", "code-server-insiders"},
 	FlavorCursor:      {"Cursor", ".cursor-server", "cursor-server"},
-	FlavorPositron:    {"positron", ".positron-server", "positron"},
-	FlavorCodium:      {"VSCodium", ".vscodium-server", "codium"},
-	FlavorWindsurf:    {"Windsurf", ".windsurf-server", "windsurf"},
-	FlavorAntigravity: {"Antigravity", ".antigravity-server", "agy"},
+	FlavorPositron:    {"positron", ".positron-server", "positron-server"},
+	FlavorCodium:      {"VSCodium", ".vscodium-server", "codium-server"},
+	FlavorWindsurf:    {"Windsurf", ".windsurf-server", "windsurf-server"},
+	FlavorAntigravity: {"Antigravity", ".antigravity-server", "antigravity-server"},
 }
 
 func (f Flavor) DisplayName() string {


### PR DESCRIPTION
A set of cleanups and small fixes to how we install extensions in VS Code flavors. In general, extensions are installed asynchronously by injecting another process into the target container that runs the VS Code server with a special command-line flag. Results of that installation are captured in `/tmp/*.stream`.

Depending on which fork you're using, you were either not getting any extensions installed (most AI flavors), or the installation could fail when you were unlucky in timing.

Please take a look at the commit messages in the individual commits for significantly more information.

- **refactor(ide/vscode): don't special-case VS Code Stable/Insiders in extension installation**
- **refactor(ide/vscode): don't consider the staging directory a valid server dir**
- **fix(ide/vscode): Always use the server binary to install extensions**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced server binary discovery for multiple VS Code variants (Positron, Codium, Windsurf, Antigravity) with improved directory traversal logic that properly excludes staging directories from binary search paths

**Chores**
- Updated server binary naming conventions across VS Code flavor configurations
- Refined extension command initialization process for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->