### PR TITLE
fix(build): pass environment variables to flatpak-spawn wrapper

### DIFF
--- a/desktop/flatpak/devpod-wrapper
+++ b/desktop/flatpak/devpod-wrapper
@@ -41,20 +41,6 @@ sync_host_binary() {
     fi
 }
 
-env_to_args() {
-    value="${DEVPOD_ADDITIONAL_ENV_VARS:-}"
-    [ -z "$value" ] && return
-
-    old_ifs="$IFS"
-    IFS=','
-    for entry in $value; do
-        case "$entry" in
-            *=*) printf '%s\n' "--env=${entry}" ;;
-        esac
-    done
-    IFS="$old_ifs"
-}
-
 main() {
     if [ -z "${FLATPAK_ID}" ]; then
         run_from_host "$@"
@@ -63,13 +49,21 @@ main() {
     sync_host_binary
     data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
 
-    env_args=""
-    for arg in $(env_to_args); do
-        env_args="$env_args $arg"
-    done
+    # Start with env flags, then --host, binary, then the original CLI args.
+    set -- "--host" "${data_home}/devpod" "$@"
+    value="${DEVPOD_ADDITIONAL_ENV_VARS:-}"
+    if [ -n "$value" ]; then
+        old_ifs="$IFS"
+        IFS=','
+        for entry in $value; do
+            case "$entry" in
+                *=*) set -- "--env=${entry}" "$@" ;;
+            esac
+        done
+        IFS="$old_ifs"
+    fi
 
-    # shellcheck disable=SC2086
-    exec /usr/bin/flatpak-spawn $env_args --host "${data_home}/devpod" "$@"
+    exec /usr/bin/flatpak-spawn "$@"
 }
 
 main "$@"


### PR DESCRIPTION
references #612 

Implements the `env_to_args` function to pass `DEVPOD_ADDITIONAL_ENV_VARS` set by the desktop application when calling the CLI to propogate env vars back to the host from the sandbox. This mirrors the approach used in https://github.com/flathub/sh.loft.devpod.

Environment variable `DEVPOD_UI` needs to be passed to the Flatpak wrapper

https://github.com/flathub/sh.loft.devpod/blob/1111cf76d46ce99758054e952d348291d208e5d4/devpod-wrapper#L4-L14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flatpak integration can now accept additional environment variables (via a configurable list) and forward them into Flatpak containers.

* **Improvements**
  * Environment variable handling in the Flatpak wrapper was improved to reliably parse, format, and pass custom variables before launching the container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->