### PR TITLE
ci: replace step with skevetter/automatic-approve-action

### DIFF
--- a/.github/workflows/workflow-approval.yml
+++ b/.github/workflows/workflow-approval.yml
@@ -10,7 +10,7 @@ jobs:
     name: Approve Workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/automatic-approve-action@v1
+      - uses: skevetter/automatic-approve-action@v2
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           workflows: "commit.yml,lint.yml,pr-ci.yml,pre-commit.yml"


### PR DESCRIPTION
The original repository for the automatic approve action is no longer maintained. I forked the action, upgraded the dependencies to the latest Node/GitHub packages, and fixed a bug where action runs get stuck in action_required status. The bug returns a HTTP 403 (cannot approve completed runs). The Promise.all causes the action to fail on the first error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow automation to use an updated third-party action while preserving existing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->