### PR TITLE
fix(desktop): tray icon for flatpaks

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -150,9 +150,20 @@ fn main() -> anyhow::Result<()> {
             let app_handle = app.handle().clone();
             tauri::async_runtime::block_on(async move {
                 if let Ok(menu) = system_tray.init(&app_handle).await {
+                    let tray_temp_dir = app
+                        .path()
+                        .app_cache_dir()
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "Failed to resolve app cache dir for tray temp path: {}. Falling back to system temp dir.",
+                                err
+                            );
+                            std::env::temp_dir().join("devpod")
+                        });
+
                     let _tray = TrayIconBuilder::with_id("main")
                         .icon(Image::from_bytes(SYSTEM_TRAY_ICON_BYTES).unwrap(),)
-                        .temp_dir_path(app.path().app_cache_dir().unwrap())
+                        .temp_dir_path(tray_temp_dir)
                         .icon_as_template(true)
                         .menu(&menu)
                         .show_menu_on_left_click(true)


### PR DESCRIPTION
Currently, flatpak installations of devpod will show a missing tray icon. By default, tauri tries to write the tray icon png into `$XDG_RUNTIME_DIR/tray-icon`, which flatpaks do not have write-permission to by default. Additionally, this default directory is not namespaced in any way such that running two tauri-based applications would write their tray icons to the same location.

It's suggested to write to the app's cache directory instead.

https://github.com/tauri-apps/tauri-docs/blob/v2/src/content/docs/distribute/flatpak.mdx

Tested to be working locally on my machine with both .deb and flatpak builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System tray now prefers the app cache directory for temporary tray files when available, improving stability and resource handling.
  * If the app cache cannot be resolved, an error is logged and the tray falls back to the system temp directory (under a "devpod" subfolder).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->