### PR TITLE
fix(driver/custom): pass provider name to ToEnvironment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,7 +179,8 @@ func inheritFlagsFromEnvironment(flags *flag.FlagSet, commandPrefix string) {
 		// do not prepend the env prefix if the flag name already starts with it
 		// (applies to one flag - "devpod-home").
 		var environmentVariable string
-		if strings.HasPrefix(suffix, config.EnvPrefix) {
+		isCanonical := strings.HasPrefix(suffix, config.EnvPrefix)
+		if isCanonical {
 			environmentVariable = suffix
 		} else {
 			environmentVariable = config.EnvPrefix + commandPrefix + suffix
@@ -187,8 +188,10 @@ func inheritFlagsFromEnvironment(flags *flag.FlagSet, commandPrefix string) {
 
 		// Fall back to the legacy unprefixed variable (e.g. DEVPOD_IDE)
 		// if the subcommand-scoped one (e.g. DEVPOD_UP_IDE) is not set.
+		// Skip fallback for canonical vars (e.g. devpod-home) where the
+		// primary lookup already uses the correct env var name.
 		value, exists := os.LookupEnv(environmentVariable)
-		if !exists && commandPrefix != "" {
+		if !exists && commandPrefix != "" && !isCanonical {
 			legacyVar := config.EnvPrefix + suffix
 			value, exists = os.LookupEnv(legacyVar)
 		}

--- a/pkg/driver/custom/custom.go
+++ b/pkg/driver/custom/custom.go
@@ -361,7 +361,7 @@ func ToEnvironWithBinaries(
 		workspace.Machine,
 		workspace.Options,
 		nil,
-		"",
+		workspace.Workspace.Provider.Name,
 	)
 	for k, v := range agentBinaries {
 		environ = append(environ, k+"="+v)

--- a/pkg/driver/custom/custom.go
+++ b/pkg/driver/custom/custom.go
@@ -361,7 +361,7 @@ func ToEnvironWithBinaries(
 		workspace.Machine,
 		workspace.Options,
 		nil,
-		workspace.Workspace.Provider.Name,
+		"",
 	)
 	for k, v := range agentBinaries {
 		environ = append(environ, k+"="+v)


### PR DESCRIPTION
## Summary
- The custom driver's `ToEnvironWithBinaries` passes an empty string for `providerName` to `ToEnvironment`, so `DEVPOD_PROVIDER` is never set in the environment for custom driver commands
- Use `workspace.Workspace.Provider.Name` to match all other call sites

## Context
Found during review of #615. All other `ToEnvironment` call sites (via `ToEnvironmentWithBinaries` in `download.go`) correctly pass `opts.Config.Name`, but the agent-side custom driver was missed.