### PR TITLE
refactor: replace acarl005/stripansi with inline regex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/PaesslerAG/jsonpath v0.1.1
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
@@ -104,6 +103,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect

--- a/pkg/pty/ptytest/ptytest.go
+++ b/pkg/pty/ptytest/ptytest.go
@@ -15,10 +15,15 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/acarl005/stripansi"
 	"github.com/skevetter/devpod/pkg/pty"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+)
+
+// ansiEscape matches ANSI/VT100 escape sequences for stripping from log output.
+var ansiEscape = regexp.MustCompile(
+	"[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|" +
+		"(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))",
 )
 
 // Timeout constants inlined from coder/testutil.
@@ -136,7 +141,7 @@ func drainLog(ex *outExpecter, logr io.Reader, done chan struct{}) {
 	for {
 		line, err := r.ReadString('\n')
 		if line != "" {
-			ex.logf("%q", stripansi.Strip(strings.TrimRight(line, "\n")))
+			ex.logf("%q", ansiEscape.ReplaceAllString(strings.TrimRight(line, "\n"), ""))
 		}
 		if err != nil {
 			return
@@ -220,7 +225,7 @@ func (e *outExpecter) ExpectNoMatchBefore(ctx context.Context, match, before str
 		)
 		return ""
 	}
-	e.logf("matched %q = %q", before, stripansi.Strip(buffer.String()))
+	e.logf("matched %q = %q", before, ansiEscape.ReplaceAllString(buffer.String(), ""))
 	return buffer.String()
 }
 


### PR DESCRIPTION
## Summary

`acarl005/stripansi` was used in a single file (`pkg/pty/ptytest/ptytest.go`) for two log-stripping calls. Inlines the same regex pattern from the upstream source to eliminate the direct dependency.

Note: `acarl005/stripansi` remains an indirect dependency via `github.com/skevetter/log`.

## Changes

- `pkg/pty/ptytest/ptytest.go`: removed `stripansi` import, added package-level `ansiEscape` regexp, replaced two `stripansi.Strip(x)` calls with `ansiEscape.ReplaceAllString(x, "")`
- `go.mod`: `acarl005/stripansi` demoted from direct to indirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized dependency management by reorganizing module dependencies.

* **Refactor**
  * Improved internal ANSI escape sequence handling for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->