### PR TITLE
refactor: replace mattn/go-isatty with golang.org/x/term

### DIFF
--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 
 	"al.essio.dev/pkg/shellescape"
-	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/skevetter/devpod/cmd/flags"
 	devagent "github.com/skevetter/devpod/pkg/agent"
@@ -276,7 +275,8 @@ func setupInteractivePTY(
 	options RunSSHSessionOptions,
 ) (func(), error) {
 	stdout := os.Stdout
-	if !isatty.IsTerminal(stdout.Fd()) {
+	fd := int(stdout.Fd()) // #nosec G115 -- fd is always a valid file descriptor
+	if !term.IsTerminal(fd) {
 		return noopRestore, nil
 	}
 
@@ -285,7 +285,6 @@ func setupInteractivePTY(
 		return noopRestore, err
 	}
 
-	fd := int(stdout.Fd()) // #nosec G115 -- fd is always a valid file descriptor
 	startWindowResizeForwarder(ctx, session, fd)
 
 	t := resolvePTYTermWithFallback(ctx, sshClient, options.SessionOptions, options.Stderr)

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/loft-sh/api/v4 v4.4.0
 	github.com/loft-sh/apiserver v0.0.0-20260113122925-594495a02e96
 	github.com/loft-sh/programming-language-detection v0.0.5
-	github.com/mattn/go-isatty v0.0.20
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/moby/buildkit v0.28.1
 	github.com/moby/patternmatcher v0.6.1
@@ -223,6 +222,7 @@ require (
 	github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect


### PR DESCRIPTION
## Summary

`mattn/go-isatty` was used in a single call site (`cmd/machine/ssh.go`) to check whether stdout is a terminal. Replaces it with `golang.org/x/term.IsTerminal()`, which is already in the module graph as a direct dependency.

Note: `mattn/go-isatty` remains an indirect dependency via `github.com/skevetter/log` → `k0kubun/go-ansi`.

## Changes

- `cmd/machine/ssh.go`: removed `go-isatty` import, replaced `isatty.IsTerminal(stdout.Fd())` with `term.IsTerminal(fd)`, hoisted `fd := int(stdout.Fd()) // #nosec G115` to satisfy gosec
- `go.mod`: `mattn/go-isatty` demoted from direct to indirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal terminal detection mechanism to reduce external dependencies while maintaining existing functionality.
  * Updated dependency management for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->