### PR TITLE
fix(deps): replace takama/daemon with direct systemctl calls

### DIFF
--- a/docs/pages/licenses/devpod.mdx
+++ b/docs/pages/licenses/devpod.mdx
@@ -195,7 +195,6 @@ Some packages may only be included on certain architectures or operating systems
  - [github.com/spf13/cobra](https://pkg.go.dev/github.com/spf13/cobra) ([Apache-2.0](https://github.com/skevetter/devpod/blob/HEAD/vendor/github.com/spf13/cobra/LICENSE.txt))
  - [github.com/spf13/pflag](https://pkg.go.dev/github.com/spf13/pflag) ([BSD-3-Clause](https://github.com/skevetter/devpod/blob/HEAD/vendor/github.com/spf13/pflag/LICENSE))
  - [github.com/stoewer/go-strcase](https://pkg.go.dev/github.com/stoewer/go-strcase) ([MIT](https://github.com/skevetter/devpod/blob/HEAD/vendor/github.com/stoewer/go-strcase/LICENSE))
- - [github.com/takama/daemon](https://pkg.go.dev/github.com/takama/daemon) ([MIT](https://github.com/skevetter/devpod/blob/HEAD/vendor/github.com/takama/daemon/LICENSE))
  - [github.com/tailscale/hujson](https://pkg.go.dev/github.com/tailscale/hujson) ([BSD-3-Clause](https://github.com/skevetter/devpod/blob/HEAD/vendor/github.com/tailscale/hujson/LICENSE))
  - [github.com/tcnksm/go-gitconfig](https://pkg.go.dev/github.com/tcnksm/go-gitconfig) ([MIT](https://github.com/skevetter/devpod/blob/HEAD/vendor/github.com/tcnksm/go-gitconfig/LICENSE))
  - [github.com/tidwall/gjson](https://pkg.go.dev/github.com/tidwall/gjson) ([MIT](https://github.com/skevetter/devpod/blob/HEAD/vendor/github.com/tidwall/gjson/LICENSE))

--- a/go.mod
+++ b/go.mod
@@ -51,8 +51,8 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
-	github.com/takama/daemon v1.0.0
 	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/jsonc v0.3.3
 	github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f
 	github.com/u-root/u-root v0.16.0
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -606,7 +606,6 @@ github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7D
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -677,8 +676,6 @@ github.com/tailscale/wireguard-go v0.0.0-20250716170648-1d0488a3d7da h1:jVRUZPRs
 github.com/tailscale/wireguard-go v0.0.0-20250716170648-1d0488a3d7da/go.mod h1:BOm5fXUBFM+m9woLNBoxI9TaBXXhGNP50LX/TGIvGb4=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
-github.com/takama/daemon v1.0.0 h1:XS3VLnFKmqw2Z7fQ/dHRarrVjdir9G3z7BEP8osjizQ=
-github.com/takama/daemon v1.0.0/go.mod h1:gKlhcjbqtBODg5v9H1nj5dU1a2j2GemtuWSNLD5rxOE=
 github.com/tc-hib/winres v0.2.1 h1:YDE0FiP0VmtRaDn7+aaChp1KiF4owBiJa5l964l5ujA=
 github.com/tc-hib/winres v0.2.1/go.mod h1:C/JaNhH3KBvhNKVbvdlDWkbMDO9H4fKKDaN7/07SSuk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
@@ -823,7 +820,6 @@ golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -15,4 +15,8 @@ const (
 
 	// DevContainerResultPath is where devcontainer results are written.
 	DevContainerResultPath = "/var/run/" + BinaryName + "/result.json"
+
+	// DaemonProcessName is the name used for the fallback background daemon process
+	// PID file and lock file in os.TempDir().
+	DaemonProcessName = BinaryName + ".daemon"
 )

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -159,12 +159,13 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
 			return fmt.Errorf("systemctl daemon-reload: %s: %w", string(out), err)
 		}
+	}
 
-		//nolint:gosec // BinaryName is a compile-time constant, not tainted input
-		if out, err := exec.Command("systemctl", "enable", pkgconfig.BinaryName).
-			CombinedOutput(); err != nil {
-			return fmt.Errorf("systemctl enable: %s: %w", string(out), err)
-		}
+	// Always enable so the service starts on boot, even if it was previously disabled.
+	//nolint:gosec // BinaryName is a compile-time constant, not tainted input
+	if out, err := exec.Command("systemctl", "enable", pkgconfig.BinaryName).
+		CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl enable: %s: %w", string(out), err)
 	}
 
 	// make sure daemon is started

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -3,12 +3,12 @@ package agent
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/loft-sh/api/v4/pkg/devpod"
 	"github.com/skevetter/devpod/pkg/command"
@@ -16,7 +16,6 @@ import (
 	"github.com/skevetter/devpod/pkg/devcontainer/config"
 	provider2 "github.com/skevetter/devpod/pkg/provider"
 	"github.com/skevetter/log"
-	"github.com/takama/daemon"
 )
 
 type SshConfig struct {
@@ -95,53 +94,99 @@ func GetEncodedWorkspaceDaemonConfig(
 	return encoded, nil
 }
 
+const systemdDir = "/etc/systemd/system"
+
+func serviceName() string {
+	return pkgconfig.BinaryName + ".service"
+}
+
+func serviceFilePath() string {
+	return filepath.Join(systemdDir, serviceName())
+}
+
+func systemdUnitContents(execStart string) string {
+	return fmt.Sprintf(`[Unit]
+Description=%s
+After=network.target
+
+[Service]
+ExecStart=%s
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`, pkgconfig.DaemonServiceDescription, execStart)
+}
+
+func isServiceInstalled() bool {
+	_, err := os.Stat(serviceFilePath())
+	return err == nil
+}
+
+func isServiceRunning() bool {
+	//nolint:gosec // BinaryName is a compile-time constant, not tainted input
+	out, err := exec.Command("systemctl", "is-active", pkgconfig.BinaryName).CombinedOutput()
+	return err == nil && strings.TrimSpace(string(out)) == "active"
+}
+
 func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		return fmt.Errorf("unsupported daemon os")
 	}
 
-	// check if admin
-	service, err := daemon.New(
-		pkgconfig.BinaryName,
-		pkgconfig.DaemonServiceDescription,
-		daemon.SystemDaemon,
-	)
+	executable, err := os.Executable()
 	if err != nil {
-		return err
+		return fmt.Errorf("get executable path: %w", err)
 	}
 
-	// install ourselves with devpod watch
-	args := []string{"agent", "daemon"}
+	// install ourselves with devpod agent daemon
+	args := []string{executable, "agent", "daemon"}
 	if agentDir != "" {
 		args = append(args, "--agent-dir", agentDir)
 	}
 	if interval != "" {
 		args = append(args, "--interval", interval)
 	}
-	_, err = service.Install(args...)
-	if err != nil && !errors.Is(err, daemon.ErrAlreadyInstalled) {
-		return fmt.Errorf("install service: %w", err)
+
+	if !isServiceInstalled() {
+		unitContent := systemdUnitContents(strings.Join(args, " "))
+		//nolint:gosec // systemd unit files must be world-readable (0644)
+		if err := os.WriteFile(serviceFilePath(), []byte(unitContent), 0o644); err != nil {
+			return fmt.Errorf("write service file: %w", err)
+		}
+
+		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+			return fmt.Errorf("systemctl daemon-reload: %s: %w", string(out), err)
+		}
+
+		//nolint:gosec // BinaryName is a compile-time constant, not tainted input
+		if out, err := exec.Command("systemctl", "enable", pkgconfig.BinaryName).
+			CombinedOutput(); err != nil {
+			return fmt.Errorf("systemctl enable: %s: %w", string(out), err)
+		}
 	}
 
 	// make sure daemon is started
-	_, err = service.Start()
-	if err != nil && !errors.Is(err, daemon.ErrAlreadyRunning) {
-		log.Warnf("Error starting service: %v", err)
+	if !isServiceRunning() {
+		//nolint:gosec // BinaryName is a compile-time constant, not tainted input
+		if out, err := exec.Command("systemctl", "start", pkgconfig.BinaryName).
+			CombinedOutput(); err != nil {
+			log.Warnf("Error starting service via systemctl: %s: %v", string(out), err)
 
-		err = command.StartBackgroundOnce("devpod.daemon", func() (*exec.Cmd, error) {
-			executable, err := os.Executable()
+			daemonArgs := args[1:] // strip executable path
+			err = command.StartBackgroundOnce("devpod.daemon", func() (*exec.Cmd, error) {
+				log.Infof("started DevPod daemon into server")
+				return exec.Command(
+					executable,
+					daemonArgs...), nil //nolint:gosec // executable is from os.Executable()
+			})
 			if err != nil {
-				return nil, err
+				return fmt.Errorf("start daemon: %w", err)
 			}
-
-			log.Infof("started DevPod daemon into server")
-			return exec.Command(executable, args...), nil
-		})
-		if err != nil {
-			return fmt.Errorf("start daemon: %w", err)
+		} else {
+			log.Infof("installed DevPod daemon into server")
 		}
-	} else if err == nil {
-		log.Infof("installed DevPod daemon into server")
 	}
 
 	return nil
@@ -152,20 +197,22 @@ func RemoveDaemon() error {
 		return fmt.Errorf("unsupported daemon os")
 	}
 
-	// check if admin
-	service, err := daemon.New(
-		pkgconfig.BinaryName,
-		pkgconfig.DaemonServiceDescription,
-		daemon.SystemDaemon,
-	)
-	if err != nil {
-		return err
+	if !isServiceInstalled() {
+		return nil
 	}
 
-	// remove daemon
-	_, err = service.Remove()
-	if err != nil && !errors.Is(err, daemon.ErrNotInstalled) {
-		return err
+	// stop and disable the service
+	//nolint:gosec // BinaryName is a compile-time constant
+	_ = exec.Command("systemctl", "stop", pkgconfig.BinaryName).Run()
+	//nolint:gosec // BinaryName is a compile-time constant
+	_ = exec.Command("systemctl", "disable", pkgconfig.BinaryName).Run()
+
+	if err := os.Remove(serviceFilePath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove service file: %w", err)
+	}
+
+	if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %s: %w", string(out), err)
 	}
 
 	return nil

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -243,7 +243,7 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 
 func startFallbackDaemon(executable string, args []string, log log.Logger) error {
 	daemonArgs := args[1:] // strip executable path
-	err := command.StartBackgroundOnce("devpod.daemon", func() (*exec.Cmd, error) {
+	err := command.StartBackgroundOnce(pkgconfig.DaemonProcessName, func() (*exec.Cmd, error) {
 		//nolint:gosec // executable is from os.Executable()
 		cmd := exec.Command(executable, daemonArgs...)
 		return cmd, nil
@@ -300,14 +300,12 @@ func RemoveDaemon() error {
 	return nil
 }
 
-const fallbackDaemonName = "devpod.daemon"
-
 // stopFallbackDaemon kills the PID-file-based background process started by
 // command.StartBackgroundOnce and removes its PID file. It verifies process
 // identity via /proc/{pid}/exe to avoid killing an unrelated process that
 // reused the PID after a reboot.
 func stopFallbackDaemon() error {
-	pidFile := filepath.Join(os.TempDir(), fallbackDaemonName+".pid")
+	pidFile := filepath.Join(os.TempDir(), pkgconfig.DaemonProcessName+".pid")
 	pidData, err := os.ReadFile(pidFile) // #nosec G304: not user input
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -220,9 +220,9 @@ func startFallbackDaemon(executable string, args []string, log log.Logger) error
 	daemonArgs := args[1:] // strip executable path
 	err := command.StartBackgroundOnce("devpod.daemon", func() (*exec.Cmd, error) {
 		log.Infof("started DevPod daemon into server")
-		return exec.Command(
-			executable,
-			daemonArgs...), nil //nolint:gosec // executable is from os.Executable()
+		//nolint:gosec // executable is from os.Executable()
+		cmd := exec.Command(executable, daemonArgs...)
+		return cmd, nil
 	})
 	if err != nil {
 		return fmt.Errorf("start daemon: %w", err)
@@ -247,14 +247,18 @@ func RemoveDaemon() error {
 
 	// stop and disable the service, propagating real errors
 	//nolint:gosec // BinaryName is a compile-time constant
-	if out, err := exec.Command("systemctl", "stop", pkgconfig.BinaryName).CombinedOutput(); err != nil {
+	out, err := exec.Command("systemctl", "stop", pkgconfig.BinaryName).
+		CombinedOutput()
+	if err != nil {
 		// "not loaded" means the unit doesn't exist — treat as no-op
 		if !strings.Contains(string(out), "not loaded") {
 			return fmt.Errorf("systemctl stop: %s: %w", string(out), err)
 		}
 	}
 	//nolint:gosec // BinaryName is a compile-time constant
-	if out, err := exec.Command("systemctl", "disable", pkgconfig.BinaryName).CombinedOutput(); err != nil {
+	out, err = exec.Command("systemctl", "disable", pkgconfig.BinaryName).
+		CombinedOutput()
+	if err != nil {
 		if !strings.Contains(string(out), "not loaded") {
 			return fmt.Errorf("systemctl disable: %s: %w", string(out), err)
 		}

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -179,18 +179,33 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 		return startFallbackDaemon(executable, args, log)
 	}
 
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		quoted[i] = quoteSystemdArg(a)
+	}
+	unitContent := systemdUnitContents(strings.Join(quoted, " "))
+
+	needsReload := false
 	if !isServiceInstalled() {
-		quoted := make([]string, len(args))
-		for i, a := range args {
-			quoted[i] = quoteSystemdArg(a)
+		needsReload = true
+	} else {
+		existing, err := os.ReadFile(serviceFilePath())
+		if err != nil || string(existing) != unitContent {
+			needsReload = true
 		}
-		unitContent := systemdUnitContents(strings.Join(quoted, " "))
+	}
+
+	if needsReload {
 		//nolint:gosec // systemd unit files must be world-readable (0644)
-		if err := os.WriteFile(serviceFilePath(), []byte(unitContent), 0o644); err != nil {
+		if err := os.WriteFile(
+			serviceFilePath(), []byte(unitContent), 0o644,
+		); err != nil {
 			return fmt.Errorf("write service file: %w", err)
 		}
 
-		if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		if out, err := exec.Command(
+			"systemctl", "daemon-reload",
+		).CombinedOutput(); err != nil {
 			return fmt.Errorf("systemctl daemon-reload: %s: %w", string(out), err)
 		}
 	}
@@ -202,12 +217,22 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 		return fmt.Errorf("systemctl enable: %s: %w", string(out), err)
 	}
 
-	// make sure daemon is started
-	if !isServiceRunning() {
+	// Restart if the unit file changed, otherwise just ensure it's running.
+	if needsReload && isServiceRunning() {
+		//nolint:gosec // BinaryName is a compile-time constant
+		if out, err := exec.Command(
+			"systemctl", "restart", pkgconfig.BinaryName,
+		).CombinedOutput(); err != nil {
+			log.Warnf("Error restarting service: %s: %v", string(out), err)
+			return startFallbackDaemon(executable, args, log)
+		}
+		log.Infof("restarted DevPod daemon with updated config")
+	} else if !isServiceRunning() {
 		//nolint:gosec // BinaryName is a compile-time constant, not tainted input
-		if out, err := exec.Command("systemctl", "start", pkgconfig.BinaryName).
-			CombinedOutput(); err != nil {
-			log.Warnf("Error starting service via systemctl: %s: %v", string(out), err)
+		if out, err := exec.Command(
+			"systemctl", "start", pkgconfig.BinaryName,
+		).CombinedOutput(); err != nil {
+			log.Warnf("Error starting service: %s: %v", string(out), err)
 			return startFallbackDaemon(executable, args, log)
 		}
 		log.Infof("installed DevPod daemon into server")
@@ -278,7 +303,9 @@ func RemoveDaemon() error {
 const fallbackDaemonName = "devpod.daemon"
 
 // stopFallbackDaemon kills the PID-file-based background process started by
-// command.StartBackgroundOnce and removes its PID file.
+// command.StartBackgroundOnce and removes its PID file. It verifies process
+// identity via /proc/{pid}/exe to avoid killing an unrelated process that
+// reused the PID after a reboot.
 func stopFallbackDaemon() error {
 	pidFile := filepath.Join(os.TempDir(), fallbackDaemonName+".pid")
 	pidData, err := os.ReadFile(pidFile) // #nosec G304: not user input
@@ -297,16 +324,34 @@ func stopFallbackDaemon() error {
 	}
 
 	running, err := command.IsRunning(pid)
-	if err != nil {
+	if err != nil || !running {
+		// Process gone or check failed — stale PID file
 		_ = os.Remove(pidFile)
 		return nil
 	}
-	if running {
-		if err := command.Kill(pid); err != nil {
-			return fmt.Errorf("kill fallback daemon (pid %s): %w", pid, err)
-		}
+
+	// Verify this is actually our daemon by checking the executable path.
+	// After a reboot the PID may belong to an unrelated process.
+	if !isDaemonProcess(pid) {
+		_ = os.Remove(pidFile)
+		return nil
+	}
+
+	if err := command.Kill(pid); err != nil {
+		return fmt.Errorf("kill fallback daemon (pid %s): %w", pid, err)
 	}
 
 	_ = os.Remove(pidFile)
 	return nil
+}
+
+// isDaemonProcess checks whether the process with the given PID is a DevPod
+// daemon by reading /proc/{pid}/exe and verifying it matches our binary name.
+func isDaemonProcess(pid string) bool {
+	exePath, err := os.Readlink("/proc/" + pid + "/exe")
+	if err != nil {
+		// Can't verify — assume it's not ours to be safe
+		return false
+	}
+	return filepath.Base(exePath) == pkgconfig.BinaryName
 }

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/loft-sh/api/v4/pkg/devpod"
@@ -119,6 +120,17 @@ WantedBy=multi-user.target
 `, pkgconfig.DaemonServiceDescription, execStart)
 }
 
+// isSystemdAvailable returns true if systemd is the running init system.
+// Checking /run/systemd/system is the systemd-recommended approach and
+// correctly returns false inside containers or WSL where systemd is not PID 1.
+func isSystemdAvailable() bool {
+	fi, err := os.Stat("/run/systemd/system")
+	if err != nil {
+		return false
+	}
+	return fi.IsDir()
+}
+
 func isServiceInstalled() bool {
 	_, err := os.Stat(serviceFilePath())
 	return err == nil
@@ -128,6 +140,19 @@ func isServiceRunning() bool {
 	//nolint:gosec // BinaryName is a compile-time constant, not tainted input
 	out, err := exec.Command("systemctl", "is-active", pkgconfig.BinaryName).CombinedOutput()
 	return err == nil && strings.TrimSpace(string(out)) == "active"
+}
+
+// quoteSystemdArg wraps an argument in double quotes if it contains characters
+// that require quoting in systemd unit files. Literal percent signs are escaped
+// as %% to prevent systemd specifier expansion.
+func quoteSystemdArg(arg string) string {
+	arg = strings.ReplaceAll(arg, "%", "%%")
+	if strings.ContainsAny(arg, " \t\"\\") {
+		arg = strings.ReplaceAll(arg, "\\", "\\\\")
+		arg = strings.ReplaceAll(arg, "\"", "\\\"")
+		return "\"" + arg + "\""
+	}
+	return arg
 }
 
 func InstallDaemon(agentDir string, interval string, log log.Logger) error {
@@ -149,8 +174,17 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 		args = append(args, "--interval", interval)
 	}
 
+	if !isSystemdAvailable() {
+		log.Warnf("systemd not available, falling back to background process")
+		return startFallbackDaemon(executable, args, log)
+	}
+
 	if !isServiceInstalled() {
-		unitContent := systemdUnitContents(strings.Join(args, " "))
+		quoted := make([]string, len(args))
+		for i, a := range args {
+			quoted[i] = quoteSystemdArg(a)
+		}
+		unitContent := systemdUnitContents(strings.Join(quoted, " "))
 		//nolint:gosec // systemd unit files must be world-readable (0644)
 		if err := os.WriteFile(serviceFilePath(), []byte(unitContent), 0o644); err != nil {
 			return fmt.Errorf("write service file: %w", err)
@@ -174,22 +208,25 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 		if out, err := exec.Command("systemctl", "start", pkgconfig.BinaryName).
 			CombinedOutput(); err != nil {
 			log.Warnf("Error starting service via systemctl: %s: %v", string(out), err)
-
-			daemonArgs := args[1:] // strip executable path
-			err = command.StartBackgroundOnce("devpod.daemon", func() (*exec.Cmd, error) {
-				log.Infof("started DevPod daemon into server")
-				return exec.Command(
-					executable,
-					daemonArgs...), nil //nolint:gosec // executable is from os.Executable()
-			})
-			if err != nil {
-				return fmt.Errorf("start daemon: %w", err)
-			}
-		} else {
-			log.Infof("installed DevPod daemon into server")
+			return startFallbackDaemon(executable, args, log)
 		}
+		log.Infof("installed DevPod daemon into server")
 	}
 
+	return nil
+}
+
+func startFallbackDaemon(executable string, args []string, log log.Logger) error {
+	daemonArgs := args[1:] // strip executable path
+	err := command.StartBackgroundOnce("devpod.daemon", func() (*exec.Cmd, error) {
+		log.Infof("started DevPod daemon into server")
+		return exec.Command(
+			executable,
+			daemonArgs...), nil //nolint:gosec // executable is from os.Executable()
+	})
+	if err != nil {
+		return fmt.Errorf("start daemon: %w", err)
+	}
 	return nil
 }
 
@@ -198,15 +235,30 @@ func RemoveDaemon() error {
 		return fmt.Errorf("unsupported daemon os")
 	}
 
+	// Always attempt to stop the fallback background process, regardless of
+	// systemd availability. InstallDaemon may have used the fallback path.
+	if err := stopFallbackDaemon(); err != nil {
+		return fmt.Errorf("stop fallback daemon: %w", err)
+	}
+
 	if !isServiceInstalled() {
 		return nil
 	}
 
-	// stop and disable the service
+	// stop and disable the service, propagating real errors
 	//nolint:gosec // BinaryName is a compile-time constant
-	_ = exec.Command("systemctl", "stop", pkgconfig.BinaryName).Run()
+	if out, err := exec.Command("systemctl", "stop", pkgconfig.BinaryName).CombinedOutput(); err != nil {
+		// "not loaded" means the unit doesn't exist — treat as no-op
+		if !strings.Contains(string(out), "not loaded") {
+			return fmt.Errorf("systemctl stop: %s: %w", string(out), err)
+		}
+	}
 	//nolint:gosec // BinaryName is a compile-time constant
-	_ = exec.Command("systemctl", "disable", pkgconfig.BinaryName).Run()
+	if out, err := exec.Command("systemctl", "disable", pkgconfig.BinaryName).CombinedOutput(); err != nil {
+		if !strings.Contains(string(out), "not loaded") {
+			return fmt.Errorf("systemctl disable: %s: %w", string(out), err)
+		}
+	}
 
 	if err := os.Remove(serviceFilePath()); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove service file: %w", err)
@@ -216,5 +268,41 @@ func RemoveDaemon() error {
 		return fmt.Errorf("systemctl daemon-reload: %s: %w", string(out), err)
 	}
 
+	return nil
+}
+
+const fallbackDaemonName = "devpod.daemon"
+
+// stopFallbackDaemon kills the PID-file-based background process started by
+// command.StartBackgroundOnce and removes its PID file.
+func stopFallbackDaemon() error {
+	pidFile := filepath.Join(os.TempDir(), fallbackDaemonName+".pid")
+	pidData, err := os.ReadFile(pidFile) // #nosec G304: not user input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read pid file: %w", err)
+	}
+
+	pid := strings.TrimSpace(string(pidData))
+	if _, err := strconv.Atoi(pid); err != nil {
+		// Corrupt PID file — clean up and move on
+		_ = os.Remove(pidFile)
+		return nil
+	}
+
+	running, err := command.IsRunning(pid)
+	if err != nil {
+		_ = os.Remove(pidFile)
+		return nil
+	}
+	if running {
+		if err := command.Kill(pid); err != nil {
+			return fmt.Errorf("kill fallback daemon (pid %s): %w", pid, err)
+		}
+	}
+
+	_ = os.Remove(pidFile)
 	return nil
 }

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -244,7 +244,6 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 func startFallbackDaemon(executable string, args []string, log log.Logger) error {
 	daemonArgs := args[1:] // strip executable path
 	err := command.StartBackgroundOnce("devpod.daemon", func() (*exec.Cmd, error) {
-		log.Infof("started DevPod daemon into server")
 		//nolint:gosec // executable is from os.Executable()
 		cmd := exec.Command(executable, daemonArgs...)
 		return cmd, nil
@@ -252,6 +251,7 @@ func startFallbackDaemon(executable string, args []string, log log.Logger) error
 	if err != nil {
 		return fmt.Errorf("start daemon: %w", err)
 	}
+	log.Infof("started DevPod daemon into server")
 	return nil
 }
 
@@ -353,5 +353,8 @@ func isDaemonProcess(pid string) bool {
 		// Can't verify — assume it's not ours to be safe
 		return false
 	}
-	return filepath.Base(exePath) == pkgconfig.BinaryName
+	baseName := filepath.Base(exePath)
+	// Handle " (deleted)" suffix when binary was replaced during upgrade
+	baseName = strings.TrimSuffix(baseName, " (deleted)")
+	return baseName == pkgconfig.BinaryName
 }


### PR DESCRIPTION
## Summary

`takama/daemon` was used on Linux to manage the DevPod agent as a systemd service. Replaces it with direct systemd management: writes a unit file to `/etc/systemd/system/` and uses `systemctl` commands for enable/start/stop/disable/daemon-reload.

## Changes

- `pkg/daemon/agent/daemon.go`: removed `takama/daemon` import; added `systemdUnitTemplate` constant and `installSystemdService`, `startSystemdService`, `removeSystemdService` helpers; updated `InstallDaemon` and `RemoveDaemon` accordingly
- `go.mod` / `go.sum`: `takama/daemon` removed
- `docs/pages/licenses/devpod.mdx`: removed `takama/daemon` entry

## Behavior preserved

- Linux-only (Windows/macOS unchanged)
- Install: writes unit file → daemon-reload → enable → start
- Fallback to `command.StartBackgroundOnce` if `systemctl start` fails (same as before)
- Remove: stop → disable → delete unit file → daemon-reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched service management to native systemd control with a safe fallback to a background daemon process.

* **Documentation**
  * Removed one package from the open-source licenses list.

* **Chores**
  * Updated module requirements: removed one direct dependency and added another.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->