### PR TITLE
fix(docker): restart and wait for container readiness before exec

### DIFF
--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/skevetter/devpod/pkg/config"
+	"github.com/skevetter/devpod/pkg/docker"
 	"github.com/skevetter/devpod/pkg/inject"
 	"github.com/skevetter/devpod/pkg/shell"
 	"github.com/skevetter/devpod/pkg/version"
@@ -192,6 +193,13 @@ func InjectAgent(opts *InjectOptions) error {
 	return retry.OnError(backoff, func(err error) bool {
 		if opts.Ctx.Err() != nil {
 			return false
+		}
+		if errors.Is(err, docker.ErrContainerTerminal) {
+			opts.Log.Errorf("container entered a terminal state, not retrying: %v", err)
+			return false
+		}
+		if strings.Contains(err.Error(), "container state improper") {
+			opts.Log.Warn("container may have stopped, it should be restarted before next exec attempt")
 		}
 		opts.Log.Debugf("retrying injection: %v", err)
 		return true

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -198,11 +198,6 @@ func InjectAgent(opts *InjectOptions) error {
 			opts.Log.Errorf("container entered a terminal state, not retrying: %v", err)
 			return false
 		}
-		if strings.Contains(err.Error(), "container state improper") {
-			opts.Log.Warn(
-				"container may have stopped, it should be restarted before next exec attempt",
-			)
-		}
 		opts.Log.Debugf("retrying injection: %v", err)
 		return true
 	}, func() error {

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -199,7 +199,9 @@ func InjectAgent(opts *InjectOptions) error {
 			return false
 		}
 		if strings.Contains(err.Error(), "container state improper") {
-			opts.Log.Warn("container may have stopped, it should be restarted before next exec attempt")
+			opts.Log.Warn(
+				"container may have stopped, it should be restarted before next exec attempt",
+			)
 		}
 		opts.Log.Debugf("retrying injection: %v", err)
 		return true

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -229,7 +229,10 @@ func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID str
 				return false, nil
 			}
 			if len(details) == 0 {
-				return false, fmt.Errorf("container %s disappeared while waiting for it to start", containerID)
+				return false, fmt.Errorf(
+				"container %s disappeared while waiting for it to start",
+				containerID,
+			)
 			}
 			status := strings.ToLower(details[0].State.Status)
 			if status == "running" {

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -11,11 +11,14 @@ import (
 	"os/exec"
 	"strings"
 
+	"time"
+
 	"github.com/skevetter/devpod/pkg/command"
 	"github.com/skevetter/devpod/pkg/devcontainer/config"
 	"github.com/skevetter/devpod/pkg/image"
 	"github.com/skevetter/log"
 	"github.com/skevetter/log/scanner"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // DockerBuilder represents the Docker builder types.
@@ -202,6 +205,42 @@ func (r *DockerHelper) StartContainer(ctx context.Context, containerId string) e
 	}
 
 	return nil
+}
+
+// ErrContainerTerminal indicates a container entered an unrecoverable state
+// (e.g. "dead" or "removing") and cannot be restarted.
+var ErrContainerTerminal = errors.New("container in terminal state")
+
+const (
+	containerRunningPollInterval = 500 * time.Millisecond
+	containerRunningTimeout      = 30 * time.Second
+)
+
+// WaitContainerRunning polls docker inspect until the container reports
+// status "running" or the context/timeout expires. It does not start
+// the container — the caller is responsible for that.
+func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID string) error {
+	return wait.PollUntilContextTimeout(ctx, containerRunningPollInterval, containerRunningTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			details, err := r.InspectContainers(ctx, []string{containerID})
+			if err != nil {
+				r.Log.Debugf("WaitContainerRunning: inspect error (will retry): %v", err)
+				return false, nil
+			}
+			if len(details) == 0 {
+				return false, fmt.Errorf("container %s disappeared while waiting for it to start", containerID)
+			}
+			status := strings.ToLower(details[0].State.Status)
+			if status == "running" {
+				return true, nil
+			}
+			if status == "removing" || status == "dead" {
+				return false, fmt.Errorf("%w: container %s is %q", ErrContainerTerminal, containerID, status)
+			}
+			r.Log.Debugf("WaitContainerRunning: container %s status=%s, waiting...", containerID, status)
+			return false, nil
+		},
+	)
 }
 
 func (r *DockerHelper) GetImageTag(ctx context.Context, imageID string) (string, error) {

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
 	"time"
 
 	"github.com/skevetter/devpod/pkg/command"

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -220,7 +220,8 @@ const (
 // status "running" or the context/timeout expires. It does not start
 // the container — the caller is responsible for that.
 func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID string) error {
-	return wait.PollUntilContextTimeout(ctx, containerRunningPollInterval, containerRunningTimeout, true,
+	return wait.PollUntilContextTimeout(
+		ctx, containerRunningPollInterval, containerRunningTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			details, err := r.InspectContainers(ctx, []string{containerID})
 			if err != nil {

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -219,11 +219,13 @@ const (
 // status "running" or the context/timeout expires. It does not start
 // the container — the caller is responsible for that.
 func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID string) error {
-	return wait.PollUntilContextTimeout(
+	var lastErr error
+	pollErr := wait.PollUntilContextTimeout(
 		ctx, containerRunningPollInterval, containerRunningTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			details, err := r.InspectContainers(ctx, []string{containerID})
 			if err != nil {
+				lastErr = err
 				r.Log.Debugf("WaitContainerRunning: inspect error (will retry): %v", err)
 				return false, nil
 			}
@@ -233,6 +235,7 @@ func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID str
 					containerID,
 				)
 			}
+			lastErr = nil
 			status := strings.ToLower(details[0].State.Status)
 			if status == "running" {
 				return true, nil
@@ -253,6 +256,10 @@ func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID str
 			return false, nil
 		},
 	)
+	if pollErr != nil && lastErr != nil {
+		return fmt.Errorf("%w (last inspect error: %v)", pollErr, lastErr)
+	}
+	return pollErr
 }
 
 func (r *DockerHelper) GetImageTag(ctx context.Context, imageID string) (string, error) {

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -230,18 +230,27 @@ func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID str
 			}
 			if len(details) == 0 {
 				return false, fmt.Errorf(
-				"container %s disappeared while waiting for it to start",
-				containerID,
-			)
+					"container %s disappeared while waiting for it to start",
+					containerID,
+				)
 			}
 			status := strings.ToLower(details[0].State.Status)
 			if status == "running" {
 				return true, nil
 			}
 			if status == "removing" || status == "dead" {
-				return false, fmt.Errorf("%w: container %s is %q", ErrContainerTerminal, containerID, status)
+				return false, fmt.Errorf(
+					"%w: container %s is %q",
+					ErrContainerTerminal,
+					containerID,
+					status,
+				)
 			}
-			r.Log.Debugf("WaitContainerRunning: container %s status=%s, waiting...", containerID, status)
+			r.Log.Debugf(
+				"WaitContainerRunning: container %s status=%s, waiting...",
+				containerID,
+				status,
+			)
 			return false, nil
 		},
 	)

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -92,7 +92,10 @@ func (d *dockerDriver) CommandDevContainer(
 	}
 
 	if container.State.Status != "running" {
-		d.Log.Infof("container %s is not running (status=%s), restarting", container.ID, container.State.Status)
+		d.Log.Infof(
+			"container %s is not running (status=%s), restarting",
+			container.ID, container.State.Status,
+		)
 		if err := d.Docker.StartContainer(ctx, container.ID); err != nil {
 			return fmt.Errorf("restart container: %w", err)
 		}

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -91,10 +91,19 @@ func (d *dockerDriver) CommandDevContainer(
 		return fmt.Errorf("container not found")
 	}
 
-	if container.State.Status != "running" {
+	status := strings.ToLower(container.State.Status)
+	if status == "dead" || status == "removing" {
+		return fmt.Errorf(
+			"%w: container %s is %q",
+			docker.ErrContainerTerminal,
+			container.ID,
+			status,
+		)
+	}
+	if status != "running" {
 		d.Log.Infof(
 			"container %s is not running (status=%s), restarting",
-			container.ID, container.State.Status,
+			container.ID, status,
 		)
 		if err := d.Docker.StartContainer(ctx, container.ID); err != nil {
 			return fmt.Errorf("restart container: %w", err)

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -91,6 +91,17 @@ func (d *dockerDriver) CommandDevContainer(
 		return fmt.Errorf("container not found")
 	}
 
+	if container.State.Status != "running" {
+		d.Log.Infof("container %s is not running (status=%s), restarting", container.ID, container.State.Status)
+		if err := d.Docker.StartContainer(ctx, container.ID); err != nil {
+			return fmt.Errorf("restart container: %w", err)
+		}
+		if err := d.Docker.WaitContainerRunning(ctx, container.ID); err != nil {
+			return fmt.Errorf("wait for container to be running: %w", err)
+		}
+		d.Log.Infof("container %s is now running", container.ID)
+	}
+
 	args := []string{"exec"}
 	if stdin != nil {
 		args = append(args, "-i")


### PR DESCRIPTION
## Summary

- Fixes flaky "Test provider on windows-latest" e2e test where Podman container exits during first exec, causing all 30 injection retries to fail against a dead container
- Adds `WaitContainerRunning` to `DockerHelper` that polls `docker inspect` (500ms interval, 30s timeout) until container is `"running"`, using the same `wait.PollUntilContextTimeout` pattern as the Kubernetes driver
- `CommandDevContainer` now detects stopped containers, restarts them, and waits for readiness before proceeding with `docker exec`
- Injection retry predicate fails fast on terminal container states (`"dead"`, `"removing"`) via sentinel error `ErrContainerTerminal` instead of burning through all retries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container state monitoring with automatic restart-and-wait so commands run only when containers are running.

* **Bug Fixes**
  * Stop retrying when a container is in a terminal state and surface clearer terminal errors.
  * Improved handling and logging when containers disappear or transition to non-runnable states, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->