### PR TITLE
refactor(provider/env): document env var contract and validate reserved names

### DIFF
--- a/pkg/provider/env.go
+++ b/pkg/provider/env.go
@@ -22,6 +22,23 @@ func combineOptions(
 	return options
 }
 
+// ToEnvironment builds the full environment for provider subprocess execution.
+// It combines the current process environment (os.Environ) with provider-specific
+// variables from three sources:
+//
+//   - ToOptions: merged provider config options (uppercased key=value pairs),
+//     plus workspace identity vars (WORKSPACE_ID, WORKSPACE_PROVIDER, etc.),
+//     machine identity vars (MACHINE_ID, MACHINE_PROVIDER, etc.),
+//     and base vars (PROVIDER_ID, PROVIDER_CONTEXT, PROVIDER_FOLDER, DEVPOD, DEVPOD_OS, DEVPOD_ARCH).
+//   - extraEnv: caller-supplied additional variables.
+//
+// The provider name is available to subprocesses as PROVIDER_ID (set by GetBaseEnvironment),
+// WORKSPACE_PROVIDER (set by ToOptionsWorkspace), and MACHINE_PROVIDER (set by ToOptionsMachine).
+//
+// Note: DEVPOD_PROVIDER is reserved by the --provider CLI flag via inheritFlagsFromEnvironment
+// in cmd/root.go. It is inherited from the parent process via os.Environ() but must not be
+// explicitly set here, as doing so would override the global provider selection for child
+// devpod processes.
 func ToEnvironment(
 	workspace *Workspace,
 	machine *Machine,
@@ -143,6 +160,11 @@ func Merge(m1 map[string]string, m2 map[string]string) map[string]string {
 	return retMap
 }
 
+// GetBaseEnvironment returns system-level env vars set for every provider subprocess:
+// DEVPOD (binary path), DEVPOD_OS, DEVPOD_ARCH, PROVIDER_ID (provider name),
+// PROVIDER_CONTEXT, PROVIDER_FOLDER, and DEVPOD_LOG_LEVEL.
+//
+// PROVIDER_ID is the canonical way for provider scripts to discover their own name.
 func GetBaseEnvironment(context, provider string) map[string]string {
 	retVars := map[string]string{}
 

--- a/pkg/provider/env_test.go
+++ b/pkg/provider/env_test.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestToEnvironment_ContainsProviderID(t *testing.T) {
+	ws := &Workspace{
+		ID:      "test-workspace",
+		Context: "default",
+		Provider: WorkspaceProviderConfig{
+			Name: "test-provider",
+		},
+		Source: WorkspaceSource{},
+	}
+
+	environ := ToEnvironment(ws, nil, nil, nil)
+
+	assertEnvContains(t, environ, "PROVIDER_ID", "test-provider")
+	assertEnvContains(t, environ, "WORKSPACE_PROVIDER", "test-provider")
+	assertEnvContains(t, environ, "WORKSPACE_ID", "test-workspace")
+}
+
+func TestToEnvironment_DoesNotDuplicateDevpodProvider(t *testing.T) {
+	ws := &Workspace{
+		ID:      "test-workspace",
+		Context: "default",
+		Provider: WorkspaceProviderConfig{
+			Name: "test-provider",
+		},
+		Source: WorkspaceSource{},
+	}
+
+	environ := ToEnvironment(ws, nil, nil, nil)
+
+	// DEVPOD_PROVIDER is reserved by the --provider CLI flag.
+	// It may appear from os.Environ() but must not be explicitly added.
+	count := 0
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, "DEVPOD_PROVIDER=") {
+			count++
+		}
+	}
+	if count > 1 {
+		t.Errorf(
+			"found %d DEVPOD_PROVIDER entries; expected at most 1 (from os.Environ)",
+			count,
+		)
+	}
+}
+
+func TestToEnvironment_IncludesExtraEnv(t *testing.T) {
+	extra := map[string]string{"CUSTOM_VAR": "custom_value"}
+	environ := ToEnvironment(nil, nil, nil, extra)
+
+	assertEnvContains(t, environ, "CUSTOM_VAR", "custom_value")
+}
+
+func assertEnvContains(t *testing.T, environ []string, key, value string) {
+	t.Helper()
+	expected := key + "=" + value
+	if !slices.Contains(environ, expected) {
+		t.Errorf("expected %s in environment, not found", expected)
+	}
+}

--- a/pkg/provider/parse.go
+++ b/pkg/provider/parse.go
@@ -18,6 +18,29 @@ var ProviderNameRegEx = regexp.MustCompile(`[^a-z0-9\-]+`)
 
 var optionNameRegEx = regexp.MustCompile(`[^A-Z0-9_]+`)
 
+// reservedOptionNames are env var names set by the DevPod runtime
+// (via GetBaseEnvironment, ToOptionsWorkspace, ToOptionsMachine).
+// Provider options must not use these names as they would silently
+// overwrite system-set values in the subprocess environment.
+var reservedOptionNames = map[string]bool{
+	"PROVIDER_ID":        true,
+	"PROVIDER_CONTEXT":   true,
+	"PROVIDER_FOLDER":    true,
+	"WORKSPACE_ID":       true,
+	"WORKSPACE_UID":      true,
+	"WORKSPACE_PROVIDER": true,
+	"WORKSPACE_CONTEXT":  true,
+	"WORKSPACE_FOLDER":   true,
+	"WORKSPACE_SOURCE":   true,
+	"WORKSPACE_ORIGIN":   true,
+	"WORKSPACE_PICTURE":  true,
+	"MACHINE_ID":         true,
+	"MACHINE_CONTEXT":    true,
+	"MACHINE_FOLDER":     true,
+	"MACHINE_PROVIDER":   true,
+	"LOFT_PROJECT":       true,
+}
+
 var allowedTypes = []string{
 	"string",
 	"multiline",
@@ -71,6 +94,14 @@ func validate(config *ProviderConfig) error {
 			return fmt.Errorf(
 				"provider option '%s' can only consist of upper case letters, numbers or underscores. "+
 					"E.g. MY_OPTION, MY_OTHER_OPTION",
+				optionName,
+			)
+		}
+
+		if reservedOptionNames[optionName] {
+			return fmt.Errorf(
+				"provider option '%s' uses a reserved environment variable name; "+
+					"choose a different name to avoid overwriting system-set values",
 				optionName,
 			)
 		}

--- a/pkg/provider/parse_test.go
+++ b/pkg/provider/parse_test.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/skevetter/devpod/pkg/types"
+)
+
+func TestValidate_RejectsReservedOptionNames(t *testing.T) {
+	reserved := []string{
+		"PROVIDER_ID",
+		"PROVIDER_CONTEXT",
+		"PROVIDER_FOLDER",
+		"WORKSPACE_ID",
+		"WORKSPACE_UID",
+		"WORKSPACE_PROVIDER",
+		"WORKSPACE_CONTEXT",
+		"WORKSPACE_FOLDER",
+		"WORKSPACE_SOURCE",
+		"WORKSPACE_ORIGIN",
+		"WORKSPACE_PICTURE",
+		"MACHINE_ID",
+		"MACHINE_CONTEXT",
+		"MACHINE_FOLDER",
+		"MACHINE_PROVIDER",
+		"LOFT_PROJECT",
+	}
+
+	for _, name := range reserved {
+		cfg := &ProviderConfig{
+			Name: "test-provider",
+			Options: map[string]*types.Option{
+				name: {Description: "test"},
+			},
+		}
+		err := validate(cfg)
+		if err == nil {
+			t.Errorf("expected error for reserved option name %q, got nil", name)
+		}
+	}
+}
+
+func TestValidate_AllowsNonReservedOptionNames(t *testing.T) {
+	cfg := &ProviderConfig{
+		Name: "test-provider",
+		Options: map[string]*types.Option{
+			"MY_CUSTOM_OPTION": {Description: "test"},
+			"AWS_REGION":       {Description: "test"},
+		},
+		Exec: ProviderCommands{
+			Command: []string{"echo hello"},
+		},
+	}
+	err := validate(cfg)
+	if err != nil {
+		t.Errorf("expected no error for non-reserved names, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #615 which identified architectural confusion around provider environment variables.

- Add validation that rejects provider option names colliding with reserved system env vars (`PROVIDER_ID`, `WORKSPACE_ID`, etc.) — prevents silent overwrites in subprocess environments
- Document the subprocess environment contract on `ToEnvironment` and `GetBaseEnvironment` with comprehensive doc comments
- Add contract tests verifying `PROVIDER_ID` is the canonical provider name source and `DEVPOD_PROVIDER` is not duplicated
- Clarify that `DEVPOD_PROVIDER` is reserved by the `--provider` CLI flag and must not be explicitly set in subprocess environments

## Test plan

- [ ] `go test ./pkg/provider/ -v` passes (5 new tests)
- [ ] `go build ./...` succeeds
- [ ] Pre-commit hooks pass
- [ ] Existing E2E tests pass (no behavioral changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and enhanced documentation describing how environment variables are constructed, inherited, and managed during provider subprocess execution.
* **Tests**
  * Added comprehensive test coverage for environment variable handling, inheritance verification, and provider configuration option validation.
* **Bug Fixes**
  * Enhanced validation to prevent and reject provider options using reserved environment variable names with clear error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->