### PR TITLE
fix(ssh): use platform raw terminal handling for PTY sessions

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -92,6 +92,20 @@ jobs:
           name: devpod-${{ steps.os.outputs.runner_os }}
           path: dist/devpod-${{ steps.os.outputs.runner_os }}_*/devpod-${{ steps.os.outputs.runner_os }}-*
 
+  unit-tests-windows:
+    name: CLI unit tests on windows-latest
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: run cmd/machine tests
+        shell: bash
+        run: go test ./cmd/machine
+
   integration-tests:
     name: Test ${{ matrix.label }} on ${{ matrix.runner }}
     needs: [can-read-secret, build-cli]

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -92,20 +92,6 @@ jobs:
           name: devpod-${{ steps.os.outputs.runner_os }}
           path: dist/devpod-${{ steps.os.outputs.runner_os }}_*/devpod-${{ steps.os.outputs.runner_os }}-*
 
-  unit-tests-windows:
-    name: CLI unit tests on windows-latest
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: run cmd/machine tests
-        shell: bash
-        run: go test ./cmd/machine
-
   integration-tests:
     name: Test ${{ matrix.label }} on ${{ matrix.runner }}
     needs: [can-read-secret, build-cli]

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -15,6 +15,7 @@ import (
 	devagent "github.com/skevetter/devpod/pkg/agent"
 	"github.com/skevetter/devpod/pkg/client"
 	"github.com/skevetter/devpod/pkg/config"
+	"github.com/skevetter/devpod/pkg/pty"
 	devssh "github.com/skevetter/devpod/pkg/ssh"
 	devsshagent "github.com/skevetter/devpod/pkg/ssh/agent"
 	"github.com/skevetter/devpod/pkg/workspace"
@@ -41,6 +42,15 @@ const (
 	defaultTerm      = "xterm-256color"
 	termModeUsage    = "PTY TERM selection mode: auto, strict, fallback"
 	installUsage     = "Install local TERM terminfo on remote before PTY"
+)
+
+var (
+	isTerminalFunc = func(fd uintptr) bool {
+		return term.IsTerminal(int(fd)) // #nosec G115 -- fd is always a valid file descriptor
+	}
+	makeInputRawTerm    = pty.MakeInputRaw
+	makeOutputRawTerm   = pty.MakeOutputRaw
+	restoreTerminalFunc = pty.RestoreTerminal
 )
 
 type SSHSessionOptions struct {
@@ -274,13 +284,14 @@ func setupInteractivePTY(
 	session *ssh.Session,
 	options RunSSHSessionOptions,
 ) (func(), error) {
+	stdin := os.Stdin
 	stdout := os.Stdout
 	fd := int(stdout.Fd()) // #nosec G115 -- fd is always a valid file descriptor
-	if !term.IsTerminal(fd) {
+	if !hasInteractiveTerminal(stdin, stdout) {
 		return noopRestore, nil
 	}
 
-	restoreTerm, err := makeRawTerm(stdout)
+	restoreTerm, err := makeRawTerm(stdin, stdout)
 	if err != nil {
 		return noopRestore, err
 	}
@@ -297,15 +308,24 @@ func setupInteractivePTY(
 	return restoreTerm, nil
 }
 
-func makeRawTerm(stdout *os.File) (func(), error) {
-	fd := int(stdout.Fd()) // #nosec G115 -- fd is always a valid file descriptor
-	state, err := term.MakeRaw(fd)
+func hasInteractiveTerminal(stdin, stdout *os.File) bool {
+	return isTerminalFunc(stdin.Fd()) && isTerminalFunc(stdout.Fd())
+}
+
+func makeRawTerm(stdin, stdout *os.File) (func(), error) {
+	stdinState, err := makeInputRawTerm(stdin.Fd())
 	if err != nil {
+		return noopRestore, err
+	}
+	stdoutState, err := makeOutputRawTerm(stdout.Fd())
+	if err != nil {
+		_ = restoreTerminalFunc(stdin.Fd(), stdinState)
 		return noopRestore, err
 	}
 
 	return func() {
-		_ = term.Restore(int(stdout.Fd()), state)
+		_ = restoreTerminalFunc(stdout.Fd(), stdoutState)
+		_ = restoreTerminalFunc(stdin.Fd(), stdinState)
 	}, nil
 }
 

--- a/cmd/machine/ssh_test.go
+++ b/cmd/machine/ssh_test.go
@@ -1,0 +1,233 @@
+package machine
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/skevetter/devpod/pkg/pty"
+)
+
+func TestHasInteractiveTerminalRequiresStdinAndStdout(t *testing.T) {
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinReader.Close() }()
+	defer func() { _ = stdinWriter.Close() }()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer func() { _ = stdoutReader.Close() }()
+	defer func() { _ = stdoutWriter.Close() }()
+
+	oldIsTerminalFunc := isTerminalFunc
+	t.Cleanup(func() {
+		isTerminalFunc = oldIsTerminalFunc
+	})
+
+	isTerminalFunc = func(fd uintptr) bool {
+		return fd == stdinReader.Fd()
+	}
+	if hasInteractiveTerminal(stdinReader, stdoutWriter) {
+		t.Fatal("expected missing stdout terminal to disable PTY")
+	}
+
+	isTerminalFunc = func(fd uintptr) bool {
+		return fd == stdinReader.Fd() || fd == stdoutWriter.Fd()
+	}
+	if !hasInteractiveTerminal(stdinReader, stdoutWriter) {
+		t.Fatal("expected PTY when both stdin and stdout are terminals")
+	}
+}
+
+func TestMakeRawTermUsesInputAndOutputTerminalState(t *testing.T) {
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinReader.Close() }()
+	defer func() { _ = stdinWriter.Close() }()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer func() { _ = stdoutReader.Close() }()
+	defer func() { _ = stdoutWriter.Close() }()
+
+	stdinState := &pty.TerminalState{}
+	stdoutState := &pty.TerminalState{}
+	var calls []string
+
+	oldMakeInputRawTerm := makeInputRawTerm
+	oldMakeOutputRawTerm := makeOutputRawTerm
+	oldRestoreTerminalFunc := restoreTerminalFunc
+	t.Cleanup(func() {
+		makeInputRawTerm = oldMakeInputRawTerm
+		makeOutputRawTerm = oldMakeOutputRawTerm
+		restoreTerminalFunc = oldRestoreTerminalFunc
+	})
+
+	makeInputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
+		calls = append(calls, "input")
+		if fd != stdinReader.Fd() {
+			t.Fatalf("expected stdin fd %d, got %d", stdinReader.Fd(), fd)
+		}
+		return stdinState, nil
+	}
+	makeOutputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
+		calls = append(calls, "output")
+		if fd != stdoutWriter.Fd() {
+			t.Fatalf("expected stdout fd %d, got %d", stdoutWriter.Fd(), fd)
+		}
+		return stdoutState, nil
+	}
+	restoreTerminalFunc = func(fd uintptr, state *pty.TerminalState) error {
+		switch {
+		case fd == stdoutWriter.Fd() && state == stdoutState:
+			calls = append(calls, "restore-output")
+		case fd == stdinReader.Fd() && state == stdinState:
+			calls = append(calls, "restore-input")
+		default:
+			t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
+		}
+		return nil
+	}
+
+	restore, err := makeRawTerm(stdinReader, stdoutWriter)
+	if err != nil {
+		t.Fatalf("make raw term: %v", err)
+	}
+	restore()
+
+	want := []string{"input", "output", "restore-output", "restore-input"}
+	if len(calls) != len(want) {
+		t.Fatalf("unexpected calls: got %v want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("unexpected calls: got %v want %v", calls, want)
+		}
+	}
+}
+
+func TestMakeRawTermRestoresInputOnOutputFailure(t *testing.T) {
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinReader.Close() }()
+	defer func() { _ = stdinWriter.Close() }()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer func() { _ = stdoutReader.Close() }()
+	defer func() { _ = stdoutWriter.Close() }()
+
+	stdinState := &pty.TerminalState{}
+	outputErr := errors.New("output raw failed")
+	var restoreCalled bool
+
+	oldMakeInputRawTerm := makeInputRawTerm
+	oldMakeOutputRawTerm := makeOutputRawTerm
+	oldRestoreTerminalFunc := restoreTerminalFunc
+	t.Cleanup(func() {
+		makeInputRawTerm = oldMakeInputRawTerm
+		makeOutputRawTerm = oldMakeOutputRawTerm
+		restoreTerminalFunc = oldRestoreTerminalFunc
+	})
+
+	makeInputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
+		if fd != stdinReader.Fd() {
+			t.Fatalf("expected stdin fd %d, got %d", stdinReader.Fd(), fd)
+		}
+		return stdinState, nil
+	}
+	makeOutputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
+		if fd != stdoutWriter.Fd() {
+			t.Fatalf("expected stdout fd %d, got %d", stdoutWriter.Fd(), fd)
+		}
+		return nil, outputErr
+	}
+	restoreTerminalFunc = func(fd uintptr, state *pty.TerminalState) error {
+		if fd != stdinReader.Fd() || state != stdinState {
+			t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
+		}
+		restoreCalled = true
+		return nil
+	}
+
+	restore, err := makeRawTerm(stdinReader, stdoutWriter)
+	if !errors.Is(err, outputErr) {
+		t.Fatalf("expected output error, got %v", err)
+	}
+	if restore == nil {
+		t.Fatal("expected restore function")
+	}
+	if !restoreCalled {
+		t.Fatal("expected stdin terminal state to be restored after output setup failure")
+	}
+}
+
+func TestMakeRawTermStopsWhenInputSetupFails(t *testing.T) {
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinReader.Close() }()
+	defer func() { _ = stdinWriter.Close() }()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer func() { _ = stdoutReader.Close() }()
+	defer func() { _ = stdoutWriter.Close() }()
+
+	inputErr := errors.New("input raw failed")
+	var outputCalled bool
+	var restoreCalled bool
+
+	oldMakeInputRawTerm := makeInputRawTerm
+	oldMakeOutputRawTerm := makeOutputRawTerm
+	oldRestoreTerminalFunc := restoreTerminalFunc
+	t.Cleanup(func() {
+		makeInputRawTerm = oldMakeInputRawTerm
+		makeOutputRawTerm = oldMakeOutputRawTerm
+		restoreTerminalFunc = oldRestoreTerminalFunc
+	})
+
+	makeInputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
+		if fd != stdinReader.Fd() {
+			t.Fatalf("expected stdin fd %d, got %d", stdinReader.Fd(), fd)
+		}
+		return nil, inputErr
+	}
+	makeOutputRawTerm = func(uintptr) (*pty.TerminalState, error) {
+		outputCalled = true
+		return &pty.TerminalState{}, nil
+	}
+	restoreTerminalFunc = func(uintptr, *pty.TerminalState) error {
+		restoreCalled = true
+		return nil
+	}
+
+	restore, err := makeRawTerm(stdinReader, stdoutWriter)
+	if !errors.Is(err, inputErr) {
+		t.Fatalf("expected input error, got %v", err)
+	}
+	if restore == nil {
+		t.Fatal("expected restore function")
+	}
+	if outputCalled {
+		t.Fatal("did not expect output raw setup after input failure")
+	}
+	if restoreCalled {
+		t.Fatal("did not expect terminal restore after input failure")
+	}
+}

--- a/cmd/machine/ssh_test.go
+++ b/cmd/machine/ssh_test.go
@@ -50,8 +50,24 @@ func TestMakeRawTermUsesInputAndOutputTerminalState(t *testing.T) {
 	restore := stubTerminalFuncs(t)
 	defer restore()
 
-	makeInputRawTerm = makeRawRecorder(t, &calls, "input", stdin.reader.Fd(), stdinState, nil)
-	makeOutputRawTerm = makeRawRecorder(t, &calls, "output", stdout.writer.Fd(), stdoutState, nil)
+	makeInputRawTerm = makeRawRecorder(
+		t,
+		rawRecorderOpts{
+			calls:  &calls,
+			label:  "input",
+			wantFD: stdin.reader.Fd(),
+			state:  stdinState,
+		},
+	)
+	makeOutputRawTerm = makeRawRecorder(
+		t,
+		rawRecorderOpts{
+			calls:  &calls,
+			label:  "output",
+			wantFD: stdout.writer.Fd(),
+			state:  stdoutState,
+		},
+	)
 	restoreTerminalFunc = restoreRecorder(t, &calls, map[uintptr]restoreCall{
 		stdout.writer.Fd(): {state: stdoutState, label: "restore-output"},
 		stdin.reader.Fd():  {state: stdinState, label: "restore-input"},
@@ -75,10 +91,18 @@ func TestMakeRawTermRestoresInputOnOutputFailure(t *testing.T) {
 	restore := stubTerminalFuncs(t)
 	defer restore()
 
-	makeInputRawTerm = makeRawRecorder(t, nil, "", stdin.reader.Fd(), stdinState, nil)
-	makeOutputRawTerm = makeRawRecorder(t, nil, "", stdout.writer.Fd(), nil, outputErr)
+	makeInputRawTerm = makeRawRecorder(
+		t,
+		rawRecorderOpts{wantFD: stdin.reader.Fd(), state: stdinState},
+	)
+	makeOutputRawTerm = makeRawRecorder(
+		t,
+		rawRecorderOpts{wantFD: stdout.writer.Fd(), err: outputErr},
+	)
 	restoreTerminalFunc = func(fd uintptr, state *pty.TerminalState) error {
-		assertRestoreCall(t, fd, state, stdin.reader.Fd(), stdinState)
+		if fd != stdin.reader.Fd() || state != stdinState {
+			t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
+		}
 		restoreCalled = true
 		return nil
 	}
@@ -104,7 +128,10 @@ func TestMakeRawTermStopsWhenInputSetupFails(t *testing.T) {
 	restore := stubTerminalFuncs(t)
 	defer restore()
 
-	makeInputRawTerm = makeRawRecorder(t, nil, "", stdin.reader.Fd(), nil, inputErr)
+	makeInputRawTerm = makeRawRecorder(
+		t,
+		rawRecorderOpts{wantFD: stdin.reader.Fd(), err: inputErr},
+	)
 	makeOutputRawTerm = func(uintptr) (*pty.TerminalState, error) {
 		outputCalled = true
 		return &pty.TerminalState{}, nil
@@ -181,24 +208,25 @@ func stubTerminalFuncs(t *testing.T) func() {
 	}
 }
 
-func makeRawRecorder(
-	t *testing.T,
-	calls *[]string,
-	label string,
-	wantFD uintptr,
-	state *pty.TerminalState,
-	err error,
-) func(uintptr) (*pty.TerminalState, error) {
+type rawRecorderOpts struct {
+	calls  *[]string
+	label  string
+	wantFD uintptr
+	state  *pty.TerminalState
+	err    error
+}
+
+func makeRawRecorder(t *testing.T, opts rawRecorderOpts) func(uintptr) (*pty.TerminalState, error) {
 	t.Helper()
 
 	return func(fd uintptr) (*pty.TerminalState, error) {
-		if calls != nil && label != "" {
-			*calls = append(*calls, label)
+		if opts.calls != nil && opts.label != "" {
+			*opts.calls = append(*opts.calls, opts.label)
 		}
-		if fd != wantFD {
-			t.Fatalf("expected fd %d, got %d", wantFD, fd)
+		if fd != opts.wantFD {
+			t.Fatalf("expected fd %d, got %d", opts.wantFD, fd)
 		}
-		return state, err
+		return opts.state, opts.err
 	}
 }
 
@@ -216,20 +244,6 @@ func restoreRecorder(
 		}
 		*calls = append(*calls, call.label)
 		return nil
-	}
-}
-
-func assertRestoreCall(
-	t *testing.T,
-	fd uintptr,
-	state *pty.TerminalState,
-	wantFD uintptr,
-	wantState *pty.TerminalState,
-) {
-	t.Helper()
-
-	if fd != wantFD || state != wantState {
-		t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
 	}
 }
 

--- a/cmd/machine/ssh_test.go
+++ b/cmd/machine/ssh_test.go
@@ -8,165 +8,79 @@ import (
 	"github.com/skevetter/devpod/pkg/pty"
 )
 
+type filePair struct {
+	reader *os.File
+	writer *os.File
+}
+
 func TestHasInteractiveTerminalRequiresStdinAndStdout(t *testing.T) {
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdin pipe: %v", err)
-	}
-	defer func() { _ = stdinReader.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
-
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdout pipe: %v", err)
-	}
-	defer func() { _ = stdoutReader.Close() }()
-	defer func() { _ = stdoutWriter.Close() }()
-
-	oldIsTerminalFunc := isTerminalFunc
-	t.Cleanup(func() {
-		isTerminalFunc = oldIsTerminalFunc
-	})
+	stdin := newPipePair(t, "stdin")
+	stdout := newPipePair(t, "stdout")
+	restore := stubIsTerminalFunc(t)
+	defer restore()
 
 	isTerminalFunc = func(fd uintptr) bool {
-		return fd == stdinReader.Fd()
+		return fd == stdin.reader.Fd()
 	}
-	if hasInteractiveTerminal(stdinReader, stdoutWriter) {
+	if hasInteractiveTerminal(stdin.reader, stdout.writer) {
 		t.Fatal("expected missing stdout terminal to disable PTY")
 	}
 
 	isTerminalFunc = func(fd uintptr) bool {
-		return fd == stdinReader.Fd() || fd == stdoutWriter.Fd()
+		return fd == stdin.reader.Fd() || fd == stdout.writer.Fd()
 	}
-	if !hasInteractiveTerminal(stdinReader, stdoutWriter) {
+	if !hasInteractiveTerminal(stdin.reader, stdout.writer) {
 		t.Fatal("expected PTY when both stdin and stdout are terminals")
 	}
 }
 
 func TestMakeRawTermUsesInputAndOutputTerminalState(t *testing.T) {
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdin pipe: %v", err)
-	}
-	defer func() { _ = stdinReader.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
-
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdout pipe: %v", err)
-	}
-	defer func() { _ = stdoutReader.Close() }()
-	defer func() { _ = stdoutWriter.Close() }()
-
+	stdin := newPipePair(t, "stdin")
+	stdout := newPipePair(t, "stdout")
 	stdinState := &pty.TerminalState{}
 	stdoutState := &pty.TerminalState{}
 	var calls []string
+	restore := stubTerminalFuncs(t)
+	defer restore()
 
-	oldMakeInputRawTerm := makeInputRawTerm
-	oldMakeOutputRawTerm := makeOutputRawTerm
-	oldRestoreTerminalFunc := restoreTerminalFunc
-	t.Cleanup(func() {
-		makeInputRawTerm = oldMakeInputRawTerm
-		makeOutputRawTerm = oldMakeOutputRawTerm
-		restoreTerminalFunc = oldRestoreTerminalFunc
+	makeInputRawTerm = makeRawRecorder(t, &calls, "input", stdin.reader.Fd(), stdinState, nil)
+	makeOutputRawTerm = makeRawRecorder(t, &calls, "output", stdout.writer.Fd(), stdoutState, nil)
+	restoreTerminalFunc = restoreRecorder(t, &calls, map[uintptr]restoreCall{
+		stdout.writer.Fd(): {state: stdoutState, label: "restore-output"},
+		stdin.reader.Fd():  {state: stdinState, label: "restore-input"},
 	})
 
-	makeInputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
-		calls = append(calls, "input")
-		if fd != stdinReader.Fd() {
-			t.Fatalf("expected stdin fd %d, got %d", stdinReader.Fd(), fd)
-		}
-		return stdinState, nil
-	}
-	makeOutputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
-		calls = append(calls, "output")
-		if fd != stdoutWriter.Fd() {
-			t.Fatalf("expected stdout fd %d, got %d", stdoutWriter.Fd(), fd)
-		}
-		return stdoutState, nil
-	}
-	restoreTerminalFunc = func(fd uintptr, state *pty.TerminalState) error {
-		switch {
-		case fd == stdoutWriter.Fd() && state == stdoutState:
-			calls = append(calls, "restore-output")
-		case fd == stdinReader.Fd() && state == stdinState:
-			calls = append(calls, "restore-input")
-		default:
-			t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
-		}
-		return nil
-	}
-
-	restore, err := makeRawTerm(stdinReader, stdoutWriter)
+	restoreTerm, err := makeRawTerm(stdin.reader, stdout.writer)
 	if err != nil {
 		t.Fatalf("make raw term: %v", err)
 	}
-	restore()
+	restoreTerm()
 
-	want := []string{"input", "output", "restore-output", "restore-input"}
-	if len(calls) != len(want) {
-		t.Fatalf("unexpected calls: got %v want %v", calls, want)
-	}
-	for i := range want {
-		if calls[i] != want[i] {
-			t.Fatalf("unexpected calls: got %v want %v", calls, want)
-		}
-	}
+	assertCallsEqual(t, calls, []string{"input", "output", "restore-output", "restore-input"})
 }
 
 func TestMakeRawTermRestoresInputOnOutputFailure(t *testing.T) {
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdin pipe: %v", err)
-	}
-	defer func() { _ = stdinReader.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
-
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdout pipe: %v", err)
-	}
-	defer func() { _ = stdoutReader.Close() }()
-	defer func() { _ = stdoutWriter.Close() }()
-
+	stdin := newPipePair(t, "stdin")
+	stdout := newPipePair(t, "stdout")
 	stdinState := &pty.TerminalState{}
 	outputErr := errors.New("output raw failed")
 	var restoreCalled bool
+	restore := stubTerminalFuncs(t)
+	defer restore()
 
-	oldMakeInputRawTerm := makeInputRawTerm
-	oldMakeOutputRawTerm := makeOutputRawTerm
-	oldRestoreTerminalFunc := restoreTerminalFunc
-	t.Cleanup(func() {
-		makeInputRawTerm = oldMakeInputRawTerm
-		makeOutputRawTerm = oldMakeOutputRawTerm
-		restoreTerminalFunc = oldRestoreTerminalFunc
-	})
-
-	makeInputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
-		if fd != stdinReader.Fd() {
-			t.Fatalf("expected stdin fd %d, got %d", stdinReader.Fd(), fd)
-		}
-		return stdinState, nil
-	}
-	makeOutputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
-		if fd != stdoutWriter.Fd() {
-			t.Fatalf("expected stdout fd %d, got %d", stdoutWriter.Fd(), fd)
-		}
-		return nil, outputErr
-	}
+	makeInputRawTerm = makeRawRecorder(t, nil, "", stdin.reader.Fd(), stdinState, nil)
+	makeOutputRawTerm = makeRawRecorder(t, nil, "", stdout.writer.Fd(), nil, outputErr)
 	restoreTerminalFunc = func(fd uintptr, state *pty.TerminalState) error {
-		if fd != stdinReader.Fd() || state != stdinState {
-			t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
-		}
+		assertRestoreCall(t, fd, state, stdin.reader.Fd(), stdinState)
 		restoreCalled = true
 		return nil
 	}
 
-	restore, err := makeRawTerm(stdinReader, stdoutWriter)
+	restoreTerm, err := makeRawTerm(stdin.reader, stdout.writer)
 	if !errors.Is(err, outputErr) {
 		t.Fatalf("expected output error, got %v", err)
 	}
-	if restore == nil {
+	if restoreTerm == nil {
 		t.Fatal("expected restore function")
 	}
 	if !restoreCalled {
@@ -175,39 +89,15 @@ func TestMakeRawTermRestoresInputOnOutputFailure(t *testing.T) {
 }
 
 func TestMakeRawTermStopsWhenInputSetupFails(t *testing.T) {
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdin pipe: %v", err)
-	}
-	defer func() { _ = stdinReader.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
-
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdout pipe: %v", err)
-	}
-	defer func() { _ = stdoutReader.Close() }()
-	defer func() { _ = stdoutWriter.Close() }()
-
+	stdin := newPipePair(t, "stdin")
+	stdout := newPipePair(t, "stdout")
 	inputErr := errors.New("input raw failed")
 	var outputCalled bool
 	var restoreCalled bool
+	restore := stubTerminalFuncs(t)
+	defer restore()
 
-	oldMakeInputRawTerm := makeInputRawTerm
-	oldMakeOutputRawTerm := makeOutputRawTerm
-	oldRestoreTerminalFunc := restoreTerminalFunc
-	t.Cleanup(func() {
-		makeInputRawTerm = oldMakeInputRawTerm
-		makeOutputRawTerm = oldMakeOutputRawTerm
-		restoreTerminalFunc = oldRestoreTerminalFunc
-	})
-
-	makeInputRawTerm = func(fd uintptr) (*pty.TerminalState, error) {
-		if fd != stdinReader.Fd() {
-			t.Fatalf("expected stdin fd %d, got %d", stdinReader.Fd(), fd)
-		}
-		return nil, inputErr
-	}
+	makeInputRawTerm = makeRawRecorder(t, nil, "", stdin.reader.Fd(), nil, inputErr)
 	makeOutputRawTerm = func(uintptr) (*pty.TerminalState, error) {
 		outputCalled = true
 		return &pty.TerminalState{}, nil
@@ -217,11 +107,11 @@ func TestMakeRawTermStopsWhenInputSetupFails(t *testing.T) {
 		return nil
 	}
 
-	restore, err := makeRawTerm(stdinReader, stdoutWriter)
+	restoreTerm, err := makeRawTerm(stdin.reader, stdout.writer)
 	if !errors.Is(err, inputErr) {
 		t.Fatalf("expected input error, got %v", err)
 	}
-	if restore == nil {
+	if restoreTerm == nil {
 		t.Fatal("expected restore function")
 	}
 	if outputCalled {
@@ -229,5 +119,122 @@ func TestMakeRawTermStopsWhenInputSetupFails(t *testing.T) {
 	}
 	if restoreCalled {
 		t.Fatal("did not expect terminal restore after input failure")
+	}
+}
+
+type restoreCall struct {
+	state *pty.TerminalState
+	label string
+}
+
+func newPipePair(t *testing.T, name string) filePair {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create %s pipe: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	return filePair{reader: reader, writer: writer}
+}
+
+func stubIsTerminalFunc(t *testing.T) func() {
+	t.Helper()
+
+	oldIsTerminalFunc := isTerminalFunc
+	t.Cleanup(func() {
+		isTerminalFunc = oldIsTerminalFunc
+	})
+
+	return func() {
+		isTerminalFunc = oldIsTerminalFunc
+	}
+}
+
+func stubTerminalFuncs(t *testing.T) func() {
+	t.Helper()
+
+	oldMakeInputRawTerm := makeInputRawTerm
+	oldMakeOutputRawTerm := makeOutputRawTerm
+	oldRestoreTerminalFunc := restoreTerminalFunc
+	t.Cleanup(func() {
+		makeInputRawTerm = oldMakeInputRawTerm
+		makeOutputRawTerm = oldMakeOutputRawTerm
+		restoreTerminalFunc = oldRestoreTerminalFunc
+	})
+
+	return func() {
+		makeInputRawTerm = oldMakeInputRawTerm
+		makeOutputRawTerm = oldMakeOutputRawTerm
+		restoreTerminalFunc = oldRestoreTerminalFunc
+	}
+}
+
+func makeRawRecorder(
+	t *testing.T,
+	calls *[]string,
+	label string,
+	wantFD uintptr,
+	state *pty.TerminalState,
+	err error,
+) func(uintptr) (*pty.TerminalState, error) {
+	t.Helper()
+
+	return func(fd uintptr) (*pty.TerminalState, error) {
+		if calls != nil && label != "" {
+			*calls = append(*calls, label)
+		}
+		if fd != wantFD {
+			t.Fatalf("expected fd %d, got %d", wantFD, fd)
+		}
+		return state, err
+	}
+}
+
+func restoreRecorder(
+	t *testing.T,
+	calls *[]string,
+	want map[uintptr]restoreCall,
+) func(uintptr, *pty.TerminalState) error {
+	t.Helper()
+
+	return func(fd uintptr, state *pty.TerminalState) error {
+		call, ok := want[fd]
+		if !ok || state != call.state {
+			t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
+		}
+		*calls = append(*calls, call.label)
+		return nil
+	}
+}
+
+func assertRestoreCall(
+	t *testing.T,
+	fd uintptr,
+	state *pty.TerminalState,
+	wantFD uintptr,
+	wantState *pty.TerminalState,
+) {
+	t.Helper()
+
+	if fd != wantFD || state != wantState {
+		t.Fatalf("unexpected restore call: fd=%d state=%p", fd, state)
+	}
+}
+
+func assertCallsEqual(t *testing.T, got, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("unexpected calls: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected calls: got %v want %v", got, want)
+		}
 	}
 }

--- a/cmd/machine/ssh_test.go
+++ b/cmd/machine/ssh_test.go
@@ -27,6 +27,13 @@ func TestHasInteractiveTerminalRequiresStdinAndStdout(t *testing.T) {
 	}
 
 	isTerminalFunc = func(fd uintptr) bool {
+		return fd == stdout.writer.Fd()
+	}
+	if hasInteractiveTerminal(stdin.reader, stdout.writer) {
+		t.Fatal("expected missing stdin terminal to disable PTY")
+	}
+
+	isTerminalFunc = func(fd uintptr) bool {
 		return fd == stdin.reader.Fd() || fd == stdout.writer.Fd()
 	}
 	if !hasInteractiveTerminal(stdin.reader, stdout.writer) {

--- a/pkg/pty/terminal_windows.go
+++ b/pkg/pty/terminal_windows.go
@@ -60,5 +60,8 @@ func makeOutputRaw(handle uintptr) (*TerminalState, error) {
 
 //nolint:revive
 func restoreTerminal(handle uintptr, state *TerminalState) error {
+	if state == nil {
+		return nil
+	}
 	return windows.SetConsoleMode(windows.Handle(handle), uint32(state.state))
 }


### PR DESCRIPTION
## Summary
- fix the interactive `devpod ssh` PTY client path to require both `stdin` and `stdout` to be terminals and to use the existing platform-aware raw terminal helpers for each handle
- restore the input terminal state if output raw-mode setup fails so Windows PowerShell / ConPTY does not get left in a partial state
- add focused regression tests for the raw terminal setup path and run `cmd/machine` tests on `windows-latest` in CI

Closes #696.

## Testing
- `mise exec go@1.24.2 -- go test ./cmd/machine`
- `GOOS=windows GOARCH=amd64 mise exec go@1.24.2 -- go test -c -o .tmp/cmd-machine-windows.test.exe ./cmd/machine`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential crash on Windows during SSH terminal operations
  * Improved error handling in SSH terminal raw-mode setup with better recovery

* **Tests**
  * Added comprehensive test coverage for SSH terminal functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->