### PR TITLE
fix(netstat): handle missing /proc/net/tcp6 on IPv6-disabled hosts

### DIFF
--- a/pkg/netstat/netstat_util.go
+++ b/pkg/netstat/netstat_util.go
@@ -246,9 +246,18 @@ func extractProcInfo(sktab []SockTabEntry) {
 }
 
 // doNetstat - collect information about network port status.
+//
+// If path does not exist (e.g. /proc/net/tcp6 on Linux hosts booted with
+// ipv6.disable=1 or built without CONFIG_IPV6), this returns an empty slice
+// and a nil error so callers can degrade gracefully instead of aborting the
+// entire port scan. All other errors, including permission and parse
+// failures, still propagate. See issue #705.
 func doNetstat(path string, fn AcceptFn) ([]SockTabEntry, error) {
 	f, err := os.Open(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	tabs, err := parseSocktab(f, fn)

--- a/pkg/netstat/netstat_util.go
+++ b/pkg/netstat/netstat_util.go
@@ -251,7 +251,6 @@ func extractProcInfo(sktab []SockTabEntry) {
 // ipv6.disable=1 or built without CONFIG_IPV6), this returns (nil, nil) so
 // callers degrade gracefully instead of aborting the entire port scan. All
 // other errors, including permission and parse failures, still propagate.
-// See issue #705.
 func doNetstat(path string, fn AcceptFn) ([]SockTabEntry, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/netstat/netstat_util.go
+++ b/pkg/netstat/netstat_util.go
@@ -248,10 +248,10 @@ func extractProcInfo(sktab []SockTabEntry) {
 // doNetstat - collect information about network port status.
 //
 // If path does not exist (e.g. /proc/net/tcp6 on Linux hosts booted with
-// ipv6.disable=1 or built without CONFIG_IPV6), this returns an empty slice
-// and a nil error so callers can degrade gracefully instead of aborting the
-// entire port scan. All other errors, including permission and parse
-// failures, still propagate. See issue #705.
+// ipv6.disable=1 or built without CONFIG_IPV6), this returns (nil, nil) so
+// callers degrade gracefully instead of aborting the entire port scan. All
+// other errors, including permission and parse failures, still propagate.
+// See issue #705.
 func doNetstat(path string, fn AcceptFn) ([]SockTabEntry, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/netstat/netstat_util_test.go
+++ b/pkg/netstat/netstat_util_test.go
@@ -1,0 +1,116 @@
+package netstat
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type NetstatUtilTestSuite struct {
+	suite.Suite
+}
+
+func TestNetstatUtilSuite(t *testing.T) {
+	suite.Run(t, new(NetstatUtilTestSuite))
+}
+
+// TestDoNetstat_MissingFileReturnsEmpty verifies that a missing procfile (as
+// seen on Linux hosts booted with ipv6.disable=1, where /proc/net/tcp6 does
+// not exist) causes doNetstat to return an empty slice and nil error rather
+// than propagating the os.IsNotExist error. This is the core regression
+// guard for issue #705.
+func (s *NetstatUtilTestSuite) TestDoNetstat_MissingFileReturnsEmpty() {
+	missing := filepath.Join(s.T().TempDir(), "does-not-exist")
+
+	entries, err := doNetstat(missing, NoopFilter)
+
+	assert.NoError(s.T(), err, "missing procfile must not error")
+	assert.Empty(s.T(), entries, "missing procfile must yield zero entries")
+}
+
+// TestDoNetstat_ParsesValidFile pins the happy-path behaviour of doNetstat so
+// the IsNotExist fix cannot accidentally suppress successful parses. The
+// synthetic content mimics the layout of /proc/net/tcp6: a header line
+// followed by one listening IPv6 socket entry on [::]:22.
+func (s *NetstatUtilTestSuite) TestDoNetstat_ParsesValidFile() {
+	// Listening on [::]:22 (ssh). Field layout mirrors /proc/net/tcp6:
+	// sl, local_address, rem_address, st, tx_queue:rx_queue, tr:tm->when,
+	// retrnsmt, uid, timeout, inode, ... parseSocktab discards the header
+	// and splits entries on whitespace, so single-spaced fields suffice.
+	// Local address is 32 hex chars (ipv6StrLen) : 4 hex port (0x0016=22).
+	// State 0x0A = Listen. UID is parsed as base-10.
+	fields := []string{
+		"0:",
+		"00000000000000000000000000000000:0016",
+		"00000000000000000000000000000000:0000",
+		"0A",
+		"00000000:00000000",
+		"00:00000000",
+		"00000000",
+		"0",
+		"0",
+		"12345",
+		"1",
+		"0000000000000000",
+		"100",
+		"0",
+		"0",
+		"10",
+		"0",
+	}
+	content := "header line discarded by parseSocktab\n" + strings.Join(fields, " ") + "\n"
+
+	path := filepath.Join(s.T().TempDir(), "tcp6")
+	require.NoError(s.T(), os.WriteFile(path, []byte(content), 0o600))
+
+	entries, err := doNetstat(path, func(e *SockTabEntry) bool {
+		return e.State == Listen
+	})
+
+	require.NoError(s.T(), err)
+	require.Len(s.T(), entries, 1)
+	assert.Equal(s.T(), uint16(22), entries[0].LocalAddr.Port)
+	assert.Equal(s.T(), Listen, entries[0].State)
+	assert.Equal(s.T(), uint32(0), entries[0].UID)
+}
+
+// TestDoNetstat_PropagatesNonNotExistOpenError verifies that the IsNotExist
+// special case is surgical: other os.Open errors (here, permission denied)
+// must still surface so real breakage is reported rather than silently
+// swallowed. Skipped on Windows (different permission model) and when
+// running as root (chmod 0 does not deny root on Linux).
+func (s *NetstatUtilTestSuite) TestDoNetstat_PropagatesNonNotExistOpenError() {
+	if runtime.GOOS == "windows" {
+		s.T().Skip("permission semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		s.T().Skip("root bypasses file-mode permission checks")
+	}
+
+	path := filepath.Join(s.T().TempDir(), "unreadable")
+	require.NoError(s.T(), os.WriteFile(path, []byte("irrelevant"), 0o000))
+	s.T().Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	_, err := doNetstat(path, NoopFilter)
+
+	require.Error(s.T(), err, "permission errors must propagate")
+	assert.False(s.T(), os.IsNotExist(err), "error should not be IsNotExist")
+}
+
+// TestDoNetstat_PropagatesParseError ensures that once the file is
+// successfully opened, malformed content still yields an error rather than
+// being hidden by the IsNotExist fix.
+func (s *NetstatUtilTestSuite) TestDoNetstat_PropagatesParseError() {
+	path := filepath.Join(s.T().TempDir(), "garbage")
+	require.NoError(s.T(), os.WriteFile(path, []byte("header\nnot enough fields here\n"), 0o600))
+
+	_, err := doNetstat(path, NoopFilter)
+
+	assert.Error(s.T(), err, "parser errors must propagate")
+}

--- a/pkg/netstat/netstat_util_test.go
+++ b/pkg/netstat/netstat_util_test.go
@@ -20,10 +20,6 @@ func TestNetstatUtilSuite(t *testing.T) {
 	suite.Run(t, new(NetstatUtilTestSuite))
 }
 
-// TestDoNetstat_MissingFileReturnsEmpty verifies that a missing procfile (as
-// seen on Linux hosts booted with ipv6.disable=1, where /proc/net/tcp6 does
-// not exist) causes doNetstat to return (nil, nil) rather than propagating
-// the os.IsNotExist error. This is the core regression guard for issue #705.
 func (s *NetstatUtilTestSuite) TestDoNetstat_MissingFileReturnsEmpty() {
 	missing := filepath.Join(s.T().TempDir(), "does-not-exist")
 
@@ -33,17 +29,8 @@ func (s *NetstatUtilTestSuite) TestDoNetstat_MissingFileReturnsEmpty() {
 	assert.Empty(s.T(), entries, "missing procfile must yield zero entries")
 }
 
-// TestDoNetstat_ParsesValidFile pins the happy-path behaviour of doNetstat so
-// the IsNotExist fix cannot accidentally suppress successful parses. The
-// synthetic content mimics the layout of /proc/net/tcp6: a header line
-// followed by one listening IPv6 socket entry on [::]:22.
 func (s *NetstatUtilTestSuite) TestDoNetstat_ParsesValidFile() {
-	// Listening on [::]:22 (ssh). Field layout mirrors /proc/net/tcp6:
-	// sl, local_address, rem_address, st, tx_queue:rx_queue, tr:tm->when,
-	// retrnsmt, uid, timeout, inode, ... parseSocktab discards the header
-	// and splits entries on whitespace, so single-spaced fields suffice.
-	// Local address is 32 hex chars (ipv6StrLen) : 4 hex port (0x0016=22).
-	// State 0x0A = Listen. UID is parsed as base-10.
+	// Synthetic /proc/net/tcp6 entry: [::]:22 (ssh), state 0A=Listen.
 	fields := []string{
 		"0:",
 		"00000000000000000000000000000000:0016",
@@ -79,11 +66,6 @@ func (s *NetstatUtilTestSuite) TestDoNetstat_ParsesValidFile() {
 	assert.Equal(s.T(), uint32(0), entries[0].UID)
 }
 
-// TestDoNetstat_PropagatesNonNotExistOpenError verifies that the IsNotExist
-// special case is surgical: other os.Open errors (here, permission denied)
-// must still surface so real breakage is reported rather than silently
-// swallowed. Skipped on Windows (different permission model) and when
-// running as root (chmod 0 does not deny root on Linux).
 func (s *NetstatUtilTestSuite) TestDoNetstat_PropagatesNonNotExistOpenError() {
 	if runtime.GOOS == "windows" {
 		s.T().Skip("permission semantics differ on Windows")
@@ -102,9 +84,6 @@ func (s *NetstatUtilTestSuite) TestDoNetstat_PropagatesNonNotExistOpenError() {
 	assert.False(s.T(), os.IsNotExist(err), "error should not be IsNotExist")
 }
 
-// TestDoNetstat_PropagatesParseError ensures that once the file is
-// successfully opened, malformed content still yields an error rather than
-// being hidden by the IsNotExist fix.
 func (s *NetstatUtilTestSuite) TestDoNetstat_PropagatesParseError() {
 	path := filepath.Join(s.T().TempDir(), "garbage")
 	require.NoError(s.T(), os.WriteFile(path, []byte("header\nnot enough fields here\n"), 0o600))

--- a/pkg/netstat/netstat_util_test.go
+++ b/pkg/netstat/netstat_util_test.go
@@ -22,9 +22,8 @@ func TestNetstatUtilSuite(t *testing.T) {
 
 // TestDoNetstat_MissingFileReturnsEmpty verifies that a missing procfile (as
 // seen on Linux hosts booted with ipv6.disable=1, where /proc/net/tcp6 does
-// not exist) causes doNetstat to return an empty slice and nil error rather
-// than propagating the os.IsNotExist error. This is the core regression
-// guard for issue #705.
+// not exist) causes doNetstat to return (nil, nil) rather than propagating
+// the os.IsNotExist error. This is the core regression guard for issue #705.
 func (s *NetstatUtilTestSuite) TestDoNetstat_MissingFileReturnsEmpty() {
 	missing := filepath.Join(s.T().TempDir(), "does-not-exist")
 


### PR DESCRIPTION
## Summary

Fixes #705. On Linux hosts where IPv6 is disabled at boot (`ipv6.disable=1`) or absent from the kernel (`CONFIG_IPV6=n`), `/proc/net/tcp6` does not exist. The devpod agent's netstat-based port watcher was returning the `os.IsNotExist` error verbatim from `doNetstat`, which propagated through `TCP6Socks` and caused `watcher.findPorts` to discard the already-collected IPv4 sockets and return an error on every tick. The net effect was that no ports were ever forwarded and IDEs like openvscode were unreachable.

## Fix

`pkg/netstat/netstat_util.go` — in `doNetstat`, treat `os.IsNotExist` from `os.Open` as "zero sockets of this family" and return `(nil, nil)`. Matches the repo's existing graceful-degradation pattern (see `pkg/gitsshsigning/helper.go`, `pkg/workspace/provider.go`, `pkg/envfile/envfile.go`). All other errors — permission, I/O, parse — still propagate unchanged.

Applied once in the common helper rather than per-caller so that `osTCPSocks`, `osTCP6Socks`, `osUDPSocks`, and `osUDP6Socks` all benefit uniformly.

## Tests

Adds `pkg/netstat/netstat_util_test.go` — the first test file in this package — with four TDD-driven tests:

1. `TestDoNetstat_MissingFileReturnsEmpty` — red-phase driver; fails before the fix, passes after.
2. `TestDoNetstat_ParsesValidFile` — pins the happy path with a synthetic `/proc/net/tcp6`-format entry (`[::]:22` LISTEN) so the fix cannot accidentally suppress successful parses.
3. `TestDoNetstat_PropagatesNonNotExistOpenError` — proves the fix is surgical by confirming permission-denied errors still bubble up. Skipped on Windows and when running as root.
4. `TestDoNetstat_PropagatesParseError` — confirms malformed content still errors.

Tests use the `testify/suite` pattern consistent with `pkg/gitsshsigning/helper_test.go` and rely only on `t.TempDir()`, so they are OS-agnostic.

## Test plan

- [x] `go test ./pkg/netstat/... -run TestNetstatUtilSuite -v` passes (all 4 tests)
- [x] `task cli:test` equivalent (`go test ./... -race -coverprofile=dist/profile.out -covermode=atomic`, excluding e2e) passes
- [x] `task cli:lint:new` (golangci-lint `--new-from-rev origin/main`) reports 0 new issues
- [x] `go vet ./pkg/netstat/...` clean
- [ ] Manual smoke test on a RHEL 9 VM booted with `ipv6.disable=1`: start a workspace, confirm openvscode is reachable and the agent log no longer shows repeated `open /proc/net/tcp6: no such file or directory` entries from the watcher.

## Follow-ups (not in this PR)

`watcher.findPorts` still discards IPv4 results if `TCP6Socks` errors for any non-IsNotExist reason. Worth hardening, but requires injecting a socket source into `Watcher` — out of scope for a bug fix. Happy to open a separate issue.

Fixes #705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Netstat reading now treats a missing proc-like netstat file as "no entries" (returns empty results) while still reporting other file access or parsing errors.

* **Tests**
  * Added tests covering missing files, successful parsing of valid netstat content, permission/open failures, and malformed-content parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->