### PR TITLE
feat: expose compose project name as env var in containers

### DIFF
--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -288,6 +288,13 @@ func (r *runner) runDockerCompose(
 		return nil, fmt.Errorf("merge config: %w", err)
 	}
 
+	// expose the compose project name inside the container
+	if mergedConfig.RemoteEnv == nil {
+		mergedConfig.RemoteEnv = map[string]string{}
+	}
+	mergedConfig.RemoteEnv["DEVPOD_COMPOSE_PROJECT_NAME"] = project.Name
+	mergedConfig.RemoteEnv["COMPOSE_PROJECT_NAME"] = project.Name
+
 	// setup container
 	return r.setupContainer(ctx, &setupContainerParams{
 		rawConfig:           parsedConfig.Raw,


### PR DESCRIPTION
## Summary

- Exports `DEVPOD_COMPOSE_PROJECT_NAME` and `COMPOSE_PROJECT_NAME` environment variables inside the main container of docker-compose backed devcontainer projects
- Allows users to identify and filter sibling compose containers using standard tooling (e.g., lazydocker, docker ps)
- Injected via the existing `remoteEnv` channel after config merging, scoped only to compose-backed workspaces

Closes #456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Docker Compose project name is now properly exposed to containers via environment variables, allowing applications running within containers to access and reference the project identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->