### PR TITLE
fix: resolve SSH signature key path for container-to-host forwarding (#645)

### DIFF
--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -162,6 +162,12 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 				"echo test > testfile",
 				"git add testfile",
 				"git commit -m 'signed test commit' 2>&1",
+				// Now test with a file-path-based signingkey (the scenario from issue #645)
+				"echo \"$(git config --global user.signingkey)\" > /tmp/test_signing_key.pub",
+				"git config --global user.signingkey /tmp/test_signing_key.pub",
+				"echo world >> file.txt",
+				"git add file.txt",
+				"git commit -m 'signed commit with file path key' 2>&1",
 			}, " && ")
 
 			// The signing key must be passed on each SSH invocation so the

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -140,7 +140,30 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			).Run()
 			framework.ExpectNoError(err)
 
-			// Add key to SSH agent so it's available for signing via the forwarded agent
+			// Start an SSH agent and add the key so it's available for signing
+			// via the forwarded agent. CI runners may not have an agent running.
+			agentOut, err := exec.Command("ssh-agent", "-s").Output()
+			framework.ExpectNoError(err)
+			// Parse SSH_AUTH_SOCK and SSH_AGENT_PID from agent output
+			for line := range strings.SplitSeq(string(agentOut), "\n") {
+				for _, prefix := range []string{"SSH_AUTH_SOCK=", "SSH_AGENT_PID="} {
+					if _, after, ok := strings.Cut(line, prefix); ok {
+						val := after
+						if semi := strings.Index(val, ";"); semi >= 0 {
+							val = val[:semi]
+						}
+						key := prefix[:len(prefix)-1]
+						_ = os.Setenv(key, val)
+					}
+				}
+			}
+			ginkgo.DeferCleanup(func(_ context.Context) {
+				if pid := os.Getenv("SSH_AGENT_PID"); pid != "" {
+					// #nosec G204 -- controlled pid from ssh-agent we started
+					_ = exec.Command("kill", pid).Run()
+				}
+			})
+
 			// #nosec G204 -- test command with controlled arguments
 			err = exec.Command("ssh-add", keyPath).Run()
 			framework.ExpectNoError(err)

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -140,9 +140,6 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			).Run()
 			framework.ExpectNoError(err)
 
-			// Start an SSH agent (CI runners may not have one) and add the
-			// signing key so it's available via the forwarded agent.
-			// GinkgoT().Setenv restores the original env when the spec ends.
 			agentOut, err := exec.Command("ssh-agent", "-s").Output()
 			framework.ExpectNoError(err)
 			t := ginkgo.GinkgoT()
@@ -191,8 +188,6 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 				"echo test > testfile",
 				"git add testfile",
 				"git commit -m 'signed test commit' 2>&1",
-				// Test file-path signingkey (issue #645): write the agent's public
-				// key to a file and point user.signingkey at it.
 				"ssh-add -L | head -1 > /tmp/test_signing_key.pub",
 				"git config --global user.signingkey /tmp/test_signing_key.pub",
 				"echo world >> file.txt",

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -143,6 +143,7 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			agentOut, err := exec.Command("ssh-agent", "-s").Output()
 			framework.ExpectNoError(err)
 			t := ginkgo.GinkgoT()
+			var agentPID string
 			for line := range strings.SplitSeq(string(agentOut), "\n") {
 				for _, prefix := range []string{"SSH_AUTH_SOCK=", "SSH_AGENT_PID="} {
 					if _, after, ok := strings.Cut(line, prefix); ok {
@@ -151,14 +152,17 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 							val = val[:semi]
 						}
 						key := prefix[:len(prefix)-1]
+						if key == "SSH_AGENT_PID" {
+							agentPID = val
+						}
 						t.Setenv(key, val)
 					}
 				}
 			}
 			ginkgo.DeferCleanup(func(_ context.Context) {
-				if pid := os.Getenv("SSH_AGENT_PID"); pid != "" {
+				if agentPID != "" {
 					// #nosec G204 -- controlled pid from ssh-agent we started
-					_ = exec.Command("kill", pid).Run()
+					_ = exec.Command("kill", agentPID).Run()
 				}
 			})
 

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -140,6 +140,11 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			).Run()
 			framework.ExpectNoError(err)
 
+			// Add key to SSH agent so it's available for signing via the forwarded agent
+			// #nosec G204 -- test command with controlled arguments
+			err = exec.Command("ssh-add", keyPath).Run()
+			framework.ExpectNoError(err)
+
 			// Start workspace with git-ssh-signing-key flag
 			err = f.DevPodUp(ctx, tempDir, "--git-ssh-signing-key", keyPath+".pub")
 			framework.ExpectNoError(err)

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -144,7 +144,11 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			// via the forwarded agent. CI runners may not have an agent running.
 			agentOut, err := exec.Command("ssh-agent", "-s").Output()
 			framework.ExpectNoError(err)
-			// Parse SSH_AUTH_SOCK and SSH_AGENT_PID from agent output
+			// Parse SSH_AUTH_SOCK and SSH_AGENT_PID from agent output.
+			// Use GinkgoT().Setenv so values are automatically restored when the
+			// spec finishes, preventing stale socket paths from leaking into
+			// subsequent ordered tests.
+			t := ginkgo.GinkgoT()
 			for line := range strings.SplitSeq(string(agentOut), "\n") {
 				for _, prefix := range []string{"SSH_AUTH_SOCK=", "SSH_AGENT_PID="} {
 					if _, after, ok := strings.Cut(line, prefix); ok {
@@ -153,7 +157,7 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 							val = val[:semi]
 						}
 						key := prefix[:len(prefix)-1]
-						_ = os.Setenv(key, val)
+						t.Setenv(key, val)
 					}
 				}
 			}
@@ -162,9 +166,6 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 					// #nosec G204 -- controlled pid from ssh-agent we started
 					_ = exec.Command("kill", pid).Run()
 				}
-				// Unset env vars so subsequent tests don't inherit a stale socket
-				_ = os.Unsetenv("SSH_AUTH_SOCK")
-				_ = os.Unsetenv("SSH_AGENT_PID")
 			})
 
 			// #nosec G204 -- test command with controlled arguments

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -162,6 +162,9 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 					// #nosec G204 -- controlled pid from ssh-agent we started
 					_ = exec.Command("kill", pid).Run()
 				}
+				// Unset env vars so subsequent tests don't inherit a stale socket
+				_ = os.Unsetenv("SSH_AUTH_SOCK")
+				_ = os.Unsetenv("SSH_AGENT_PID")
 			})
 
 			// #nosec G204 -- test command with controlled arguments

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -140,14 +140,11 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			).Run()
 			framework.ExpectNoError(err)
 
-			// Start an SSH agent and add the key so it's available for signing
-			// via the forwarded agent. CI runners may not have an agent running.
+			// Start an SSH agent (CI runners may not have one) and add the
+			// signing key so it's available via the forwarded agent.
+			// GinkgoT().Setenv restores the original env when the spec ends.
 			agentOut, err := exec.Command("ssh-agent", "-s").Output()
 			framework.ExpectNoError(err)
-			// Parse SSH_AUTH_SOCK and SSH_AGENT_PID from agent output.
-			// Use GinkgoT().Setenv so values are automatically restored when the
-			// spec finishes, preventing stale socket paths from leaking into
-			// subsequent ordered tests.
 			t := ginkgo.GinkgoT()
 			for line := range strings.SplitSeq(string(agentOut), "\n") {
 				for _, prefix := range []string{"SSH_AUTH_SOCK=", "SSH_AGENT_PID="} {
@@ -194,9 +191,8 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 				"echo test > testfile",
 				"git add testfile",
 				"git commit -m 'signed test commit' 2>&1",
-				// Now test with a file-path-based signingkey (the scenario from issue #645).
-				// Get the actual public key from the forwarded SSH agent since user.signingkey
-				// is a host path that doesn't exist inside the container.
+				// Test file-path signingkey (issue #645): write the agent's public
+				// key to a file and point user.signingkey at it.
 				"ssh-add -L | head -1 > /tmp/test_signing_key.pub",
 				"git config --global user.signingkey /tmp/test_signing_key.pub",
 				"echo world >> file.txt",

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -162,8 +162,10 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 				"echo test > testfile",
 				"git add testfile",
 				"git commit -m 'signed test commit' 2>&1",
-				// Now test with a file-path-based signingkey (the scenario from issue #645)
-				"echo \"$(git config --global user.signingkey)\" > /tmp/test_signing_key.pub",
+				// Now test with a file-path-based signingkey (the scenario from issue #645).
+				// Get the actual public key from the forwarded SSH agent since user.signingkey
+				// is a host path that doesn't exist inside the container.
+				"ssh-add -L | head -1 > /tmp/test_signing_key.pub",
 				"git config --global user.signingkey /tmp/test_signing_key.pub",
 				"echo world >> file.txt",
 				"git add file.txt",

--- a/pkg/agent/tunnelserver/tunnelserver_gitssh_test.go
+++ b/pkg/agent/tunnelserver/tunnelserver_gitssh_test.go
@@ -1,0 +1,41 @@
+package tunnelserver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/skevetter/devpod/pkg/agent/tunnel"
+	"github.com/skevetter/devpod/pkg/gitsshsigning"
+	"github.com/skevetter/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitSSHSignature_DeserializesPublicKey(t *testing.T) {
+	req := gitsshsigning.GitSSHSignatureRequest{
+		Content:   "tree abc\nauthor Test\n\ncommit",
+		KeyPath:   "/container/tmp/.git_signing_key_tmpXXX",
+		PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFake test@test.com",
+	}
+	reqJSON, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	ts := New(log.Discard)
+
+	// This will fail at ssh-keygen (no real key in agent), but we can verify
+	// the error is from ssh-keygen execution (not JSON parsing or key resolution),
+	// proving the PublicKey was resolved and signing was attempted.
+	_, err = ts.GitSSHSignature(context.Background(), &tunnel.Message{
+		Message: string(reqJSON),
+	})
+	require.Error(t, err)
+	// The error should be about signing failure (ssh-keygen ran), not about
+	// JSON deserialization or key file resolution.
+	assert.NotContains(t, err.Error(), "git ssh sign request",
+		"request should deserialize without error")
+	assert.NotContains(t, err.Error(), "resolve signing key",
+		"PublicKey should be resolved to a temp file without error")
+	assert.Contains(t, err.Error(), "failed to sign commit",
+		"error should be from ssh-keygen execution, proving signing was attempted")
+}

--- a/pkg/agent/tunnelserver/tunnelserver_gitssh_test.go
+++ b/pkg/agent/tunnelserver/tunnelserver_gitssh_test.go
@@ -23,8 +23,6 @@ func TestGitSSHSignature_DeserializesPublicKey(t *testing.T) {
 
 	ts := New(log.Discard)
 
-	// Signing fails (no real key in agent), but the error should come from
-	// ssh-keygen execution — not from deserialization or key resolution.
 	_, err = ts.GitSSHSignature(context.Background(), &tunnel.Message{
 		Message: string(reqJSON),
 	})

--- a/pkg/agent/tunnelserver/tunnelserver_gitssh_test.go
+++ b/pkg/agent/tunnelserver/tunnelserver_gitssh_test.go
@@ -23,19 +23,13 @@ func TestGitSSHSignature_DeserializesPublicKey(t *testing.T) {
 
 	ts := New(log.Discard)
 
-	// This will fail at ssh-keygen (no real key in agent), but we can verify
-	// the error is from ssh-keygen execution (not JSON parsing or key resolution),
-	// proving the PublicKey was resolved and signing was attempted.
+	// Signing fails (no real key in agent), but the error should come from
+	// ssh-keygen execution — not from deserialization or key resolution.
 	_, err = ts.GitSSHSignature(context.Background(), &tunnel.Message{
 		Message: string(reqJSON),
 	})
 	require.Error(t, err)
-	// The error should be about signing failure (ssh-keygen ran), not about
-	// JSON deserialization or key file resolution.
-	assert.NotContains(t, err.Error(), "git ssh sign request",
-		"request should deserialize without error")
-	assert.NotContains(t, err.Error(), "resolve signing key",
-		"PublicKey should be resolved to a temp file without error")
-	assert.Contains(t, err.Error(), "failed to sign commit",
-		"error should be from ssh-keygen execution, proving signing was attempted")
+	assert.NotContains(t, err.Error(), "git ssh sign request")
+	assert.NotContains(t, err.Error(), "resolve signing key")
+	assert.Contains(t, err.Error(), "failed to sign commit")
 }

--- a/pkg/credentials/integration_test.go
+++ b/pkg/credentials/integration_test.go
@@ -103,7 +103,10 @@ func TestIntegration_SignatureRequest_IncludesPublicKeyContent(t *testing.T) {
 					"-----BEGIN SSH SIGNATURE-----\ntest\n-----END SSH SIGNATURE-----\n",
 				),
 			}
-			jsonBytes, _ := json.Marshal(sig)
+			jsonBytes, err := json.Marshal(sig)
+			if err != nil {
+				return nil, fmt.Errorf("marshal sig: %w", err)
+			}
 			return &tunnel.Message{Message: string(jsonBytes)}, nil
 		},
 	}

--- a/pkg/credentials/integration_test.go
+++ b/pkg/credentials/integration_test.go
@@ -92,3 +92,49 @@ func TestIntegration_SigningSuccess_WritesSigFile(t *testing.T) {
 	require.NoError(t, readErr)
 	assert.Equal(t, expectedSig, sigContent)
 }
+
+func TestIntegration_SignatureRequest_IncludesPublicKeyContent(t *testing.T) {
+	var receivedMessage string
+	mock := &mockTunnelClient{
+		gitSSHSignatureFunc: func(ctx context.Context, msg *tunnel.Message) (*tunnel.Message, error) {
+			receivedMessage = msg.Message
+			sig := gitsshsigning.GitSSHSignatureResponse{
+				Signature: []byte(
+					"-----BEGIN SSH SIGNATURE-----\ntest\n-----END SSH SIGNATURE-----\n",
+				),
+			}
+			jsonBytes, _ := json.Marshal(sig)
+			return &tunnel.Message{Message: string(jsonBytes)}, nil
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := handleGitSSHSignatureRequest(context.Background(), w, r, mock, log.Discard)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	gitsshsigning.SetSignatureServerURL(server.URL + "/git-ssh-signature")
+	t.Cleanup(func() { gitsshsigning.SetSignatureServerURL("") })
+
+	// Create a cert file with known content
+	tmpDir := t.TempDir()
+	certFile := filepath.Join(tmpDir, "test_key.pub")
+	pubKeyContent := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com"
+	require.NoError(t, os.WriteFile(certFile, []byte(pubKeyContent), 0o600))
+
+	bufferFile := filepath.Join(tmpDir, "buffer")
+	require.NoError(t, os.WriteFile(bufferFile, []byte("commit content"), 0o600))
+
+	err := gitsshsigning.HandleGitSSHProgramCall(certFile, "git", bufferFile, log.Discard)
+	require.NoError(t, err)
+
+	// Verify the request forwarded to the tunnel contains the public key content
+	var req gitsshsigning.GitSSHSignatureRequest
+	require.NoError(t, json.Unmarshal([]byte(receivedMessage), &req))
+	assert.Equal(t, pubKeyContent, req.PublicKey,
+		"the tunnel message should include the public key content")
+	assert.Equal(t, "commit content", req.Content)
+}

--- a/pkg/credentials/integration_test.go
+++ b/pkg/credentials/integration_test.go
@@ -119,7 +119,6 @@ func TestIntegration_SignatureRequest_IncludesPublicKeyContent(t *testing.T) {
 	gitsshsigning.SetSignatureServerURL(server.URL + "/git-ssh-signature")
 	t.Cleanup(func() { gitsshsigning.SetSignatureServerURL("") })
 
-	// Create a cert file with known content
 	tmpDir := t.TempDir()
 	certFile := filepath.Join(tmpDir, "test_key.pub")
 	pubKeyContent := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com"
@@ -131,10 +130,8 @@ func TestIntegration_SignatureRequest_IncludesPublicKeyContent(t *testing.T) {
 	err := gitsshsigning.HandleGitSSHProgramCall(certFile, "git", bufferFile, log.Discard)
 	require.NoError(t, err)
 
-	// Verify the request forwarded to the tunnel contains the public key content
 	var req gitsshsigning.GitSSHSignatureRequest
 	require.NoError(t, json.Unmarshal([]byte(receivedMessage), &req))
-	assert.Equal(t, pubKeyContent, req.PublicKey,
-		"the tunnel message should include the public key content")
+	assert.Equal(t, pubKeyContent, req.PublicKey)
 	assert.Equal(t, "commit content", req.Content)
 }

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -349,8 +349,15 @@ func establishSSHSession(
 }
 
 // setupSSHAgentForwarding configures SSH agent forwarding on the session.
-// Failures are logged but not fatal — agent forwarding is optional and
-// SSH_AUTH_SOCK commonly points to stale sockets (tmux, screen, etc.).
+//
+// Failures are logged but never fatal. This matches OpenSSH's behavior:
+//   - clientloop.c: client_request_agent() returns NULL on failure,
+//     sending SSH2_MSG_CHANNEL_OPEN_FAILURE without terminating the session.
+//   - ssh_config(5) ExitOnForwardFailure only covers "dynamic, tunnel,
+//     local, and remote port forwardings" — agent forwarding is excluded.
+//
+// Stale SSH_AUTH_SOCK is common in practice (tmux, screen, reconnected
+// terminals), so a fatal error here would break devpod up for many users.
 func setupSSHAgentForwarding(
 	ts *sshSessionTunnel,
 	sshClient *ssh.Client,

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -349,7 +349,8 @@ func establishSSHSession(
 }
 
 // setupSSHAgentForwarding configures SSH agent forwarding on the session.
-// Errors are returned to the caller rather than sent to a channel directly.
+// Failures are logged but not fatal — agent forwarding is optional and
+// SSH_AUTH_SOCK commonly points to stale sockets (tmux, screen, etc.).
 func setupSSHAgentForwarding(
 	ts *sshSessionTunnel,
 	sshClient *ssh.Client,
@@ -368,9 +369,9 @@ func setupSSHAgentForwarding(
 	}
 
 	if err != nil {
-		ts.opts.Log.Warnf("SSH agent forwarding failed: %v", err)
+		ts.opts.Log.Warnf("SSH agent forwarding failed (continuing without agent): %v", err)
 	}
-	return err
+	return nil
 }
 
 // runCommandInSSHTunnel runs the agent command over the SSH tunnel and returns

--- a/pkg/gitsshsigning/client.go
+++ b/pkg/gitsshsigning/client.go
@@ -80,9 +80,8 @@ func writeSignatureToFile(signature []byte, bufferFile string, log log.Logger) e
 }
 
 func createSignatureRequestBody(content []byte, certPath string) ([]byte, error) {
-	// Read the public key content so the host can write it to a temp file.
-	// If the file is unreadable (e.g. non-existent), we omit PublicKey and
-	// fall back to KeyPath for backward compatibility.
+	// Include the public key content so the host can create a temp file;
+	// the container-local certPath doesn't exist on the host.
 	var publicKey string
 	pubKeyData, readErr := os.ReadFile(
 		certPath,

--- a/pkg/gitsshsigning/client.go
+++ b/pkg/gitsshsigning/client.go
@@ -80,9 +80,21 @@ func writeSignatureToFile(signature []byte, bufferFile string, log log.Logger) e
 }
 
 func createSignatureRequestBody(content []byte, certPath string) ([]byte, error) {
+	// Read the public key content so the host can write it to a temp file.
+	// If the file is unreadable (e.g. non-existent), we omit PublicKey and
+	// fall back to KeyPath for backward compatibility.
+	var publicKey string
+	pubKeyData, readErr := os.ReadFile(
+		certPath,
+	) // #nosec G304 -- certPath comes from git config, not user input
+	if readErr == nil {
+		publicKey = strings.TrimSpace(string(pubKeyData))
+	}
+
 	request := &GitSSHSignatureRequest{
-		Content: string(content),
-		KeyPath: certPath,
+		Content:   string(content),
+		KeyPath:   certPath,
+		PublicKey: publicKey,
 	}
 	return json.Marshal(request)
 }

--- a/pkg/gitsshsigning/client.go
+++ b/pkg/gitsshsigning/client.go
@@ -80,8 +80,6 @@ func writeSignatureToFile(signature []byte, bufferFile string, log log.Logger) e
 }
 
 func createSignatureRequestBody(content []byte, certPath string) ([]byte, error) {
-	// Include the public key content so the host can create a temp file;
-	// the container-local certPath doesn't exist on the host.
 	var publicKey string
 	pubKeyData, readErr := os.ReadFile(
 		certPath,

--- a/pkg/gitsshsigning/client_test.go
+++ b/pkg/gitsshsigning/client_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/skevetter/log"
@@ -95,4 +97,30 @@ func TestRequestContentSignature_InvalidJSON(t *testing.T) {
 	_, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub", log.Discard)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not json at all")
+}
+
+func TestCreateSignatureRequestBody_IncludesPublicKeyContent(t *testing.T) {
+	certPath := filepath.Join(t.TempDir(), "test_key.pub")
+	pubKeyContent := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com"
+	require.NoError(t, os.WriteFile(certPath, []byte(pubKeyContent), 0o600))
+
+	body, err := createSignatureRequestBody([]byte("commit content"), certPath)
+	require.NoError(t, err)
+
+	var req GitSSHSignatureRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	assert.Equal(t, "commit content", req.Content)
+	assert.Equal(t, certPath, req.KeyPath)
+	assert.Equal(t, pubKeyContent, req.PublicKey,
+		"request should include the public key file content so the host can create a temp file")
+}
+
+func TestCreateSignatureRequestBody_MissingCertFile_OmitsPublicKey(t *testing.T) {
+	body, err := createSignatureRequestBody([]byte("commit content"), "/nonexistent/key.pub")
+	require.NoError(t, err)
+
+	var req GitSSHSignatureRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	assert.Empty(t, req.PublicKey,
+		"when cert file is unreadable, PublicKey should be empty for backward compat")
 }

--- a/pkg/gitsshsigning/client_test.go
+++ b/pkg/gitsshsigning/client_test.go
@@ -111,8 +111,7 @@ func TestCreateSignatureRequestBody_IncludesPublicKeyContent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &req))
 	assert.Equal(t, "commit content", req.Content)
 	assert.Equal(t, certPath, req.KeyPath)
-	assert.Equal(t, pubKeyContent, req.PublicKey,
-		"request should include the public key file content so the host can create a temp file")
+	assert.Equal(t, pubKeyContent, req.PublicKey)
 }
 
 func TestCreateSignatureRequestBody_MissingCertFile_OmitsPublicKey(t *testing.T) {
@@ -121,6 +120,5 @@ func TestCreateSignatureRequestBody_MissingCertFile_OmitsPublicKey(t *testing.T)
 
 	var req GitSSHSignatureRequest
 	require.NoError(t, json.Unmarshal(body, &req))
-	assert.Empty(t, req.PublicKey,
-		"when cert file is unreadable, PublicKey should be empty for backward compat")
+	assert.Empty(t, req.PublicKey)
 }

--- a/pkg/gitsshsigning/server.go
+++ b/pkg/gitsshsigning/server.go
@@ -3,12 +3,14 @@ package gitsshsigning
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
 type GitSSHSignatureRequest struct {
-	Content string
-	KeyPath string
+	Content   string
+	KeyPath   string
+	PublicKey string // Public key content; when set, written to a temp file for ssh-keygen
 }
 
 type GitSSHSignatureResponse struct {
@@ -18,22 +20,38 @@ type GitSSHSignatureResponse struct {
 // Sign signs the content using the private key and returns the signature.
 // This is intended to be a drop-in replacement for gpg.ssh.program for git,
 // so we simply execute ssh-keygen in the same way as git would do locally.
+//
+// When PublicKey is set, it is written to a temporary file that ssh-keygen
+// can read. This is necessary because the original KeyPath comes from
+// inside the container and does not exist on the host where Sign() runs.
 func (req *GitSSHSignatureRequest) Sign() (*GitSSHSignatureResponse, error) {
-	// Create a buffer to store the commit content
+	keyFile, cleanup, err := req.resolveKeyFile()
+	if err != nil {
+		return nil, fmt.Errorf("resolve signing key: %w", err)
+	}
+	defer cleanup()
+
 	var commitBuffer bytes.Buffer
 	commitBuffer.WriteString(req.Content)
 
-	// Create the command to run ssh-keygen
-	cmd := exec.Command("ssh-keygen", "-Y", "sign", "-f", req.KeyPath, "-n", "git")
+	//nolint:gosec // keyFile is a controlled temp path or validated KeyPath
+	cmd := exec.Command(
+		"ssh-keygen",
+		"-Y",
+		"sign",
+		"-f",
+		keyFile,
+		"-n",
+		"git",
+	)
 	cmd.Stdin = &commitBuffer
 
-	// Capture the output of the command
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign commit: %w, stderr: %s", err, stderr.String())
 	}
@@ -41,4 +59,38 @@ func (req *GitSSHSignatureRequest) Sign() (*GitSSHSignatureResponse, error) {
 	return &GitSSHSignatureResponse{
 		Signature: out.Bytes(),
 	}, nil
+}
+
+// resolveKeyFile returns the path to use for ssh-keygen -f and a cleanup function.
+// When PublicKey content is available, it writes a temp file. Otherwise falls back to KeyPath.
+func (req *GitSSHSignatureRequest) resolveKeyFile() (string, func(), error) {
+	noop := func() {}
+
+	if req.PublicKey == "" {
+		return req.KeyPath, noop, nil
+	}
+
+	// ssh-keygen -Y sign -f <key> looks for <key>.pub to identify the agent key.
+	// We write the public key to a temp file with a .pub suffix and pass the
+	// path without the .pub suffix to -f.
+	tmpFile, err := os.CreateTemp("", ".git_signing_key_*.pub")
+	if err != nil {
+		return "", noop, fmt.Errorf("create temp key file: %w", err)
+	}
+	pubPath := tmpFile.Name()
+	// keyPath is the path without .pub, passed to ssh-keygen -f
+	keyPath := pubPath[:len(pubPath)-len(".pub")]
+
+	if _, err := tmpFile.WriteString(req.PublicKey); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(pubPath)
+		return "", noop, fmt.Errorf("write public key: %w", err)
+	}
+	_ = tmpFile.Close()
+
+	cleanup := func() {
+		_ = os.Remove(pubPath)
+	}
+
+	return keyPath, cleanup, nil
 }

--- a/pkg/gitsshsigning/server.go
+++ b/pkg/gitsshsigning/server.go
@@ -70,26 +70,24 @@ func (req *GitSSHSignatureRequest) resolveKeyFile() (string, func(), error) {
 		return req.KeyPath, noop, nil
 	}
 
-	// ssh-keygen -Y sign -f <key> looks for <key>.pub to identify the agent key.
-	// We write the public key to a temp file with a .pub suffix and pass the
-	// path without the .pub suffix to -f.
-	tmpFile, err := os.CreateTemp("", ".git_signing_key_*.pub")
+	// ssh-keygen -Y sign -f <path> reads the public key directly from <path>
+	// to identify which SSH agent key to use for signing. We write the public
+	// key content to a temp file and pass that path to -f.
+	tmpFile, err := os.CreateTemp("", ".git_signing_key_*")
 	if err != nil {
 		return "", noop, fmt.Errorf("create temp key file: %w", err)
 	}
-	pubPath := tmpFile.Name()
-	// keyPath is the path without .pub, passed to ssh-keygen -f
-	keyPath := pubPath[:len(pubPath)-len(".pub")]
+	keyPath := tmpFile.Name()
 
 	if _, err := tmpFile.WriteString(req.PublicKey); err != nil {
 		_ = tmpFile.Close()
-		_ = os.Remove(pubPath)
+		_ = os.Remove(keyPath)
 		return "", noop, fmt.Errorf("write public key: %w", err)
 	}
 	_ = tmpFile.Close()
 
 	cleanup := func() {
-		_ = os.Remove(pubPath)
+		_ = os.Remove(keyPath)
 	}
 
 	return keyPath, cleanup, nil

--- a/pkg/gitsshsigning/server_test.go
+++ b/pkg/gitsshsigning/server_test.go
@@ -1,0 +1,19 @@
+package gitsshsigning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSign_NonExistentKeyPath_ReturnsError(t *testing.T) {
+	req := &GitSSHSignatureRequest{
+		Content: "tree abc123\nauthor Test <test@example.com>\n\ntest commit",
+		KeyPath: "/tmp/.git_signing_key_does_not_exist",
+	}
+
+	_, err := req.Sign()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to sign commit")
+}

--- a/pkg/gitsshsigning/server_test.go
+++ b/pkg/gitsshsigning/server_test.go
@@ -14,8 +14,6 @@ func TestSign_WithPublicKeyContent_WritesToTempFile(t *testing.T) {
 		PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting test@example.com",
 	}
 
-	// Signing fails (fake key not in agent), but the error should reference
-	// a host temp file, not the original container KeyPath.
 	_, err := req.Sign()
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "/tmp/.git_signing_key_does_not_exist")

--- a/pkg/gitsshsigning/server_test.go
+++ b/pkg/gitsshsigning/server_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSign_WithPublicKeyContent_WritesToTempFile(t *testing.T) {
+	// This test verifies the new behavior: when PublicKey is provided,
+	// Sign() writes it to a temp file and uses that for ssh-keygen.
+	// We can't do a full sign without a real key in the agent, but we
+	// can verify the temp file is created and cleaned up.
+	req := &GitSSHSignatureRequest{
+		Content:   "tree abc123\nauthor Test <test@example.com>\n\ntest commit",
+		KeyPath:   "/tmp/.git_signing_key_does_not_exist",
+		PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting test@example.com",
+	}
+
+	// Sign will fail because the fake key isn't in the agent, but the error
+	// should NOT reference the original KeyPath (container path). Instead it
+	// should reference a temp file path that was created on the host.
+	_, err := req.Sign()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "/tmp/.git_signing_key_does_not_exist",
+		"with PublicKey set, Sign should use a temp file path, not the container KeyPath")
+}
+
 func TestSign_NonExistentKeyPath_ReturnsError(t *testing.T) {
 	req := &GitSSHSignatureRequest{
 		Content: "tree abc123\nauthor Test <test@example.com>\n\ntest commit",

--- a/pkg/gitsshsigning/server_test.go
+++ b/pkg/gitsshsigning/server_test.go
@@ -8,23 +8,17 @@ import (
 )
 
 func TestSign_WithPublicKeyContent_WritesToTempFile(t *testing.T) {
-	// This test verifies the new behavior: when PublicKey is provided,
-	// Sign() writes it to a temp file and uses that for ssh-keygen.
-	// We can't do a full sign without a real key in the agent, but we
-	// can verify the temp file is created and cleaned up.
 	req := &GitSSHSignatureRequest{
 		Content:   "tree abc123\nauthor Test <test@example.com>\n\ntest commit",
 		KeyPath:   "/tmp/.git_signing_key_does_not_exist",
 		PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting test@example.com",
 	}
 
-	// Sign will fail because the fake key isn't in the agent, but the error
-	// should NOT reference the original KeyPath (container path). Instead it
-	// should reference a temp file path that was created on the host.
+	// Signing fails (fake key not in agent), but the error should reference
+	// a host temp file, not the original container KeyPath.
 	_, err := req.Sign()
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "/tmp/.git_signing_key_does_not_exist",
-		"with PublicKey set, Sign should use a temp file path, not the container KeyPath")
+	assert.NotContains(t, err.Error(), "/tmp/.git_signing_key_does_not_exist")
 }
 
 func TestSign_NonExistentKeyPath_ReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #645 — Git SSH signature forwarding fails because the container-local temp key path (`/tmp/.git_signing_key_tmpXXXXXX`) is forwarded verbatim to the host's `Sign()` function, where `ssh-keygen` can't find it.

### Core fix: public key content forwarding

- **Container client** (`client.go`): reads the public key file content and includes it as `PublicKey` in the signature request
- **Host server** (`server.go`): `Sign()` calls `resolveKeyFile()` which writes the `PublicKey` content to a host-local temp file before invoking `ssh-keygen`
- Backward compatible: when `PublicKey` is empty, falls back to `KeyPath`

### Non-fatal SSH agent forwarding

- **SSH tunnel** (`sshtunnel.go`): agent forwarding failure is now logged as a warning instead of fatally aborting `devpod up`
- Matches OpenSSH behavior: `clientloop.c` returns NULL on agent failure without terminating the session; `ExitOnForwardFailure` in `ssh_config(5)` explicitly excludes agent forwarding
- Stale `SSH_AUTH_SOCK` is common in practice (tmux, screen, reconnected terminals)

### Test coverage

- Unit tests for `Sign()` with `PublicKey` content and non-existent key paths
- Client tests for public key reading and request body construction
- Integration test verifying `PublicKey` flows through the tunnel
- Tunnel server test for `PublicKey` deserialization
- E2e test for file-path-based signing key scenario (the exact issue #645 case)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signature requests now include public key content when available, and signing accepts an inline public key.

* **Bug Fixes**
  * SSH agent forwarding failures in dev containers are non-fatal; workflows continue without agent forwarding.

* **Tests**
  * Added end-to-end and unit tests validating local agent usage, inclusion of public key content in requests, and signing error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->