### PR TITLE
feat: replace PrintTable with lipgloss table renderer

### DIFF
--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/skevetter/devpod/pkg/config"
-	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +65,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			return tableEntries[i][0] < tableEntries[j][0]
 		})
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Default",
 		}, tableEntries)

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/skevetter/devpod/pkg/config"
-	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/spf13/cobra"
 )
 
@@ -73,7 +72,7 @@ func (cmd *OptionsCmd) Run(ctx context.Context, args []string) error {
 			return tableEntries[i][0] < tableEntries[j][0]
 		})
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Description",
 			"Default",

--- a/cmd/ide/list.go
+++ b/cmd/ide/list.go
@@ -10,8 +10,7 @@ import (
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/skevetter/devpod/pkg/config"
 	"github.com/skevetter/devpod/pkg/ide/ideparse"
-	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +67,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			return tableEntries[i][0] < tableEntries[j][0]
 		})
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Default",
 		}, tableEntries)

--- a/cmd/ide/options.go
+++ b/cmd/ide/options.go
@@ -10,8 +10,7 @@ import (
 	"github.com/skevetter/devpod/pkg/config"
 	"github.com/skevetter/devpod/pkg/ide"
 	"github.com/skevetter/devpod/pkg/ide/ideparse"
-	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/spf13/cobra"
 )
 
@@ -79,7 +78,7 @@ func (cmd *OptionsCmd) Run(ctx context.Context, ide string) error {
 			return tableEntries[i][0] < tableEntries[j][0]
 		})
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Description",
 			"Default",

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/skevetter/devpod/pkg/config"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/skevetter/devpod/pkg/workspace"
 	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
 	"github.com/spf13/cobra"
 )
 
@@ -88,7 +88,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			})
 		}
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Source",
 			"Machine",

--- a/cmd/machine/list.go
+++ b/cmd/machine/list.go
@@ -11,8 +11,7 @@ import (
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/skevetter/devpod/pkg/config"
 	"github.com/skevetter/devpod/pkg/provider"
-	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/spf13/cobra"
 )
 
@@ -81,7 +80,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			return tableEntries[i][0] < tableEntries[j][0]
 		})
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Provider",
 			"Age",

--- a/cmd/pro/list.go
+++ b/cmd/pro/list.go
@@ -10,9 +10,9 @@ import (
 	proflags "github.com/skevetter/devpod/cmd/pro/flags"
 	"github.com/skevetter/devpod/pkg/config"
 	"github.com/skevetter/devpod/pkg/provider"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/skevetter/devpod/pkg/workspace"
 	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
 	"github.com/spf13/cobra"
 )
 
@@ -87,7 +87,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			tableHeaders = append(tableHeaders, "Authenticated")
 		}
 
-		table.PrintTable(log.Default, tableHeaders, tableEntries)
+		table.Print(tableHeaders, tableEntries)
 	case "json":
 		tableEntries := []*proTableEntry{}
 		for _, proInstance := range proInstances {

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/skevetter/devpod/pkg/config"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/skevetter/devpod/pkg/types"
 	"github.com/skevetter/devpod/pkg/workspace"
 	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
 	"github.com/spf13/cobra"
 )
 
@@ -82,7 +82,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			return tableEntries[i][0] < tableEntries[j][0]
 		})
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Version",
 			"Default",

--- a/cmd/provider/options.go
+++ b/cmd/provider/options.go
@@ -11,10 +11,10 @@ import (
 	"github.com/skevetter/devpod/cmd/completion"
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/skevetter/devpod/pkg/config"
+	"github.com/skevetter/devpod/pkg/table"
 	"github.com/skevetter/devpod/pkg/types"
 	"github.com/skevetter/devpod/pkg/workspace"
 	"github.com/skevetter/log"
-	"github.com/skevetter/log/table"
 	"github.com/spf13/cobra"
 )
 
@@ -131,7 +131,7 @@ func printOptions(
 			return tableEntries[i][0] < tableEntries[j][0]
 		})
 
-		table.PrintTable(log.Default, []string{
+		table.Print([]string{
 			"Name",
 			"Required",
 			"Description",

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/huh v0.8.0
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/compose-spec/compose-go/v2 v2.10.2
 	github.com/containers/image/v5 v5.36.2
 	github.com/creack/pty v1.1.24
@@ -120,12 +121,10 @@ require (
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
 	github.com/charmbracelet/bubbletea v1.3.6 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/clipperhouse/displaywidth v0.6.2 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/coder/websocket v1.8.12 // indirect
@@ -152,7 +151,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
@@ -232,10 +230,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
-	github.com/olekukonko/errors v1.1.0 // indirect
-	github.com/olekukonko/ll v0.1.3 // indirect
-	github.com/olekukonko/tablewriter v1.1.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,6 @@ github.com/charmbracelet/x/xpty v0.1.2 h1:Pqmu4TEJ8KeA9uSkISKMU3f+C1F6OGBn8ABuGl
 github.com/charmbracelet/x/xpty v0.1.2/go.mod h1:XK2Z0id5rtLWcpeNiMYBccNNBrP2IJnzHI0Lq13Xzq4=
 github.com/cilium/ebpf v0.16.0 h1:+BiEnHL6Z7lXnlGUsXQPPAE7+kenAd4ES8MQ5min0Ok=
 github.com/cilium/ebpf v0.16.0/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEngfwE=
-github.com/clipperhouse/displaywidth v0.6.2 h1:ZDpTkFfpHOKte4RG5O/BOyf3ysnvFswpyYrV7z2uAKo=
-github.com/clipperhouse/displaywidth v0.6.2/go.mod h1:R+kHuzaYWFkTm7xoMmK1lFydbci4X2CicfbGstSGg0o=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
@@ -553,14 +551,6 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
-github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6/go.mod h1:rEKTHC9roVVicUIfZK7DYrdIoM0EOr8mK1Hj5s3JjH0=
-github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=
-github.com/olekukonko/errors v1.1.0/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
-github.com/olekukonko/ll v0.1.3 h1:sV2jrhQGq5B3W0nENUISCR6azIPf7UBUpVq0x/y70Fg=
-github.com/olekukonko/ll v0.1.3/go.mod h1:b52bVQRRPObe+yyBl0TxNfhesL0nedD4Cht0/zx55Ew=
-github.com/olekukonko/tablewriter v1.1.2 h1:L2kI1Y5tZBct/O/TyZK1zIE9GlBj/TVs+AY5tZDCDSc=
-github.com/olekukonko/tablewriter v1.1.2/go.mod h1:z7SYPugVqGVavWoA2sGsFIoOVNmEHxUAAMrhXONtfkg=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -1,0 +1,38 @@
+package table
+
+import (
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"golang.org/x/term"
+)
+
+// Render builds a table string from headers and rows.
+func Render(headers []string, rows [][]string) string {
+	headerStyle := lipgloss.NewStyle().Bold(true)
+	cellStyle := lipgloss.NewStyle()
+
+	t := table.New().
+		Headers(headers...).
+		Rows(rows...).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("238"))).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return headerStyle
+			}
+			return cellStyle
+		})
+
+	width, _, err := term.GetSize(int(os.Stdout.Fd())) //nolint:gosec
+	if err == nil && width > 0 {
+		t = t.Width(width)
+	}
+
+	return t.Render()
+}
+
+// Print renders a table to stdout.
+func Print(headers []string, rows [][]string) {
+	os.Stdout.WriteString(Render(headers, rows) + "\n") //nolint:errcheck,gosec
+}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -24,7 +24,9 @@ func Render(headers []string, rows [][]string) string {
 			return cellStyle
 		})
 
-	width, _, err := term.GetSize(int(os.Stdout.Fd())) //nolint:gosec
+	width, _, err := term.GetSize(
+		int(os.Stdout.Fd()), //nolint:gosec // G115: safe int conversion of stdout fd
+	)
 	if err == nil && width > 0 {
 		t = t.Width(width)
 	}
@@ -34,5 +36,7 @@ func Render(headers []string, rows [][]string) string {
 
 // Print renders a table to stdout.
 func Print(headers []string, rows [][]string) {
-	os.Stdout.WriteString(Render(headers, rows) + "\n") //nolint:errcheck,gosec
+	os.Stdout.WriteString( //nolint:errcheck,gosec // G104: stdout write error is non-actionable
+		Render(headers, rows) + "\n",
+	)
 }

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -36,7 +36,5 @@ func Render(headers []string, rows [][]string) string {
 
 // Print renders a table to stdout.
 func Print(headers []string, rows [][]string) {
-	os.Stdout.WriteString( //nolint:errcheck,gosec // G104: stdout write error is non-actionable
-		Render(headers, rows) + "\n",
-	)
+	_, _ = os.Stdout.WriteString(Render(headers, rows) + "\n") //nolint:gosec // G104
 }

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -1,0 +1,40 @@
+package table
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRender(t *testing.T) {
+	headers := []string{"Name", "Age"}
+	rows := [][]string{
+		{"Alice", "30"},
+		{"Bob", "25"},
+	}
+
+	out := Render(headers, rows)
+
+	if !strings.Contains(out, "Alice") {
+		t.Errorf("expected output to contain 'Alice', got:\n%s", out)
+	}
+	if !strings.Contains(out, "Bob") {
+		t.Errorf("expected output to contain 'Bob', got:\n%s", out)
+	}
+	if !strings.Contains(out, "Name") {
+		t.Errorf("expected output to contain header 'Name', got:\n%s", out)
+	}
+	if !strings.Contains(out, "Age") {
+		t.Errorf("expected output to contain header 'Age', got:\n%s", out)
+	}
+}
+
+func TestRenderEmpty(t *testing.T) {
+	headers := []string{"Name", "Age"}
+	rows := [][]string{}
+
+	out := Render(headers, rows)
+
+	if !strings.Contains(out, "Name") {
+		t.Errorf("expected output to contain header 'Name', got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds new `pkg/table` package using `charmbracelet/lipgloss/table` for terminal-width-aware rendering
- Migrates all 9 `table.PrintTable(log.Default, ...)` call sites to `table.Print(...)`
- Decouples table rendering from the logging library — writes directly to stdout
- Removes `olekukonko/tablewriter` transitive dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced table rendering with improved visual styling across list and output commands.

* **Tests**
  * Added test coverage for the new table rendering system.

* **Chores**
  * Updated dependencies to support enhanced table display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->