### PR TITLE
refactor: inline analytics-client to remove loft-sh dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/loft-sh/agentapi/v4 v4.8.1
-	github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
 	github.com/loft-sh/api/v4 v4.4.0
 	github.com/loft-sh/apiserver v0.0.0-20260113122925-594495a02e96
 	github.com/moby/buildkit v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,6 @@ github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0 h1:12fy1LhhyuQ4
 github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0/go.mod h1:pp+2PgOsRCTb1DXnEev/HCc0gvj5t0nHuTIMU8C8b90=
 github.com/loft-sh/agentapi/v4 v4.8.1 h1:o50ZvSS9R62gaWYcZl6uhVYnhYb6KbBvuOCiIpqUX1E=
 github.com/loft-sh/agentapi/v4 v4.8.1/go.mod h1:imoDDofcfZKLEy8Mpt0gWUKQWAXQ3oUVEyfWFil9Vdc=
-github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e h1:JcPnMaoczikvpasi8OJ47dCkWZjfgFubWa4V2SZo7h0=
-github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e/go.mod h1:FFWcGASyM2QlWTDTCG/WBVM/XYr8btqYt335TFNRCFg=
 github.com/loft-sh/api/v4 v4.4.0 h1:RP4YsNay7xqay0oxb8g4n7NECVxE/ogQApFov8Z4nZ8=
 github.com/loft-sh/api/v4 v4.4.0/go.mod h1:LqPbhgISsMvxIucmEUe42ifwuAG6kyqSBy1WTcrtGPQ=
 github.com/loft-sh/apiserver v0.0.0-20260113122925-594495a02e96 h1:MnvrgRnVm7X8zQPyVS2U2veIxacmVUYSFTHsoi6sJrw=

--- a/pkg/telemetry/analytics/buffer.go
+++ b/pkg/telemetry/analytics/buffer.go
@@ -1,0 +1,62 @@
+package analytics
+
+import "sync"
+
+func newEventBuffer(size int) *eventBuffer {
+	return &eventBuffer{
+		bufferSize: size,
+		buffer:     make([]Event, 0, size),
+		fullChan:   make(chan struct{}),
+	}
+}
+
+type eventBuffer struct {
+	m          sync.Mutex
+	bufferSize int
+	buffer     []Event
+
+	fullOnce sync.Once
+	fullChan chan struct{}
+}
+
+func (e *eventBuffer) Drain() []Event {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	e.close()
+	return e.buffer
+}
+
+func (e *eventBuffer) Full() <-chan struct{} {
+	return e.fullChan
+}
+
+func (e *eventBuffer) IsFull() bool {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	return len(e.buffer) >= e.bufferSize
+}
+
+func (e *eventBuffer) Append(ev Event) bool {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	wasAdded := false
+	if len(e.buffer) < e.bufferSize {
+		e.buffer = append(e.buffer, ev)
+		wasAdded = true
+	}
+
+	if len(e.buffer) >= e.bufferSize {
+		e.close()
+	}
+
+	return wasAdded
+}
+
+func (e *eventBuffer) close() {
+	e.fullOnce.Do(func() {
+		close(e.fullChan)
+	})
+}

--- a/pkg/telemetry/analytics/client.go
+++ b/pkg/telemetry/analytics/client.go
@@ -1,0 +1,167 @@
+package analytics
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/skevetter/log"
+)
+
+const (
+	defaultEndpoint = "https://analytics.loft.rocks/v1/insert"
+
+	eventsCountThreshold = 100
+
+	maxUploadInterval = 5 * time.Minute
+	minUploadInterval = 30 * time.Second
+)
+
+var Dry = false
+
+func NewClient() Client {
+	c := &client{
+		endpoint: defaultEndpoint,
+
+		buffer:   newEventBuffer(eventsCountThreshold),
+		overflow: newEventBuffer(eventsCountThreshold),
+
+		events:     make(chan Event, 100),
+		httpClient: http.Client{Timeout: 3 * time.Second},
+		log:        log.Default.WithPrefix("analytics"),
+	}
+
+	go c.loop()
+
+	return c
+}
+
+type client struct {
+	buffer        *eventBuffer
+	overflow      *eventBuffer
+	droppedEvents int
+	bufferMutex   sync.Mutex
+
+	events chan Event
+
+	endpoint string
+
+	httpClient http.Client
+	log        log.Logger
+}
+
+func (c *client) RecordEvent(event Event) {
+	c.events <- event
+}
+
+func (c *client) Flush() {
+	c.bufferMutex.Lock()
+	isFull := c.buffer.IsFull()
+	c.bufferMutex.Unlock()
+
+	if !isFull {
+		startTime := time.Now()
+		for time.Since(startTime) < 500*time.Millisecond {
+			time.Sleep(10 * time.Millisecond)
+			if len(c.events) == 0 {
+				break
+			}
+		}
+	}
+
+	c.executeUpload(c.exchangeBuffer())
+}
+
+func (c *client) loop() {
+	go func() {
+		for event := range c.events {
+			c.bufferMutex.Lock()
+			if !c.buffer.Append(event) && !c.overflow.Append(event) {
+				c.droppedEvents++
+			}
+			c.bufferMutex.Unlock()
+		}
+	}()
+
+	for {
+		startWait := time.Now()
+		c.bufferMutex.Lock()
+		fullChan := c.buffer.Full()
+		c.bufferMutex.Unlock()
+
+		select {
+		case <-fullChan:
+			timeSinceStart := time.Since(startWait)
+			if timeSinceStart < minUploadInterval {
+				time.Sleep(minUploadInterval - timeSinceStart)
+			}
+		case <-time.After(maxUploadInterval):
+		}
+
+		c.Flush()
+	}
+}
+
+func (c *client) executeUpload(buffer []Event) {
+	if len(buffer) == 0 {
+		return
+	}
+
+	request := &Request{
+		Data: buffer,
+	}
+
+	if Dry {
+		marshaled, err := json.MarshalIndent(request, "", "  ")
+		if err != nil {
+			c.log.Debugf("failed to marshal analytics request: %v", err)
+			return
+		}
+		c.log.Infof("analytics request: %s", string(marshaled))
+		return
+	}
+
+	marshaled, err := json.Marshal(request)
+	if err != nil {
+		c.log.Debugf("failed to marshal analytics request: %v", err)
+		return
+	}
+
+	resp, err := c.httpClient.Post(c.endpoint, "application/json", bytes.NewReader(marshaled))
+	if err != nil {
+		c.log.Debugf("error sending analytics request: %v", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		out, err := io.ReadAll(resp.Body)
+		if err != nil {
+			c.log.Debugf("error reading analytics response body: %v", err)
+			return
+		}
+		c.log.Debugf(
+			"analytics request returned non-200 status: %s",
+			fmt.Sprintf("%s%v", string(out), err),
+		)
+	}
+}
+
+func (c *client) exchangeBuffer() []Event {
+	c.bufferMutex.Lock()
+	defer c.bufferMutex.Unlock()
+
+	if c.droppedEvents > 0 {
+		c.log.Debugf("dropped %d analytics events (buffer full)", c.droppedEvents)
+	}
+
+	events := c.buffer.Drain()
+	c.buffer = c.overflow
+	c.overflow = newEventBuffer(eventsCountThreshold)
+	c.droppedEvents = 0
+	return events
+}

--- a/pkg/telemetry/analytics/client.go
+++ b/pkg/telemetry/analytics/client.go
@@ -3,7 +3,6 @@ package analytics
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"sync"
@@ -55,7 +54,10 @@ type client struct {
 }
 
 func (c *client) RecordEvent(event Event) {
-	c.events <- event
+	select {
+	case c.events <- event:
+	default:
+	}
 }
 
 func (c *client) Flush() {
@@ -144,10 +146,7 @@ func (c *client) executeUpload(buffer []Event) {
 			c.log.Debugf("error reading analytics response body: %v", err)
 			return
 		}
-		c.log.Debugf(
-			"analytics request returned non-200 status: %s",
-			fmt.Sprintf("%s%v", string(out), err),
-		)
+		c.log.Debugf("analytics request returned status %d: %s", resp.StatusCode, string(out))
 	}
 }
 

--- a/pkg/telemetry/analytics/noop.go
+++ b/pkg/telemetry/analytics/noop.go
@@ -1,0 +1,11 @@
+package analytics
+
+func NewNoopClient() Client {
+	return &noopClient{}
+}
+
+type noopClient struct{}
+
+func (n *noopClient) RecordEvent(event Event) {}
+
+func (n *noopClient) Flush() {}

--- a/pkg/telemetry/analytics/types.go
+++ b/pkg/telemetry/analytics/types.go
@@ -1,0 +1,12 @@
+package analytics
+
+type Event map[string]map[string]any
+
+type Client interface {
+	RecordEvent(Event)
+	Flush()
+}
+
+type Request struct {
+	Data []Event `json:"data,omitempty"`
+}

--- a/pkg/telemetry/collect.go
+++ b/pkg/telemetry/collect.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/loft-sh/analytics-client/client"
 	"github.com/moby/term"
 	devpodclient "github.com/skevetter/devpod/pkg/client"
 	"github.com/skevetter/devpod/pkg/config"
+	"github.com/skevetter/devpod/pkg/telemetry/analytics"
 	"github.com/skevetter/devpod/pkg/version"
 	"github.com/skevetter/log"
 	"github.com/spf13/cobra"
@@ -71,7 +71,7 @@ func StartCLI(devPodConfig *config.Config, cmd *cobra.Command) {
 
 func newCLICollector(cmd *cobra.Command) (*cliCollector, error) {
 	defaultCollector := &cliCollector{
-		analyticsClient: client.NewClient(),
+		analyticsClient: analytics.NewClient(),
 		log:             log.Default.WithPrefix("telemetry"),
 		cmd:             cmd,
 	}
@@ -80,7 +80,7 @@ func newCLICollector(cmd *cobra.Command) (*cliCollector, error) {
 }
 
 type cliCollector struct {
-	analyticsClient client.Client
+	analyticsClient analytics.Client
 	cmd             *cobra.Command
 	client          devpodclient.BaseWorkspaceClient
 
@@ -160,7 +160,7 @@ func (d *cliCollector) RecordCLI(err error) {
 	// build the event and record
 	eventPropertiesRaw, _ := json.Marshal(eventProperties)
 	userPropertiesRaw, _ := json.Marshal(userProperties)
-	d.analyticsClient.RecordEvent(client.Event{
+	d.analyticsClient.RecordEvent(analytics.Event{
 		"event": {
 			"type":       eventType,
 			"machine_id": GetMachineID(),


### PR DESCRIPTION
## Summary
- Vendors the `github.com/loft-sh/analytics-client` package (~160 lines) directly into `pkg/telemetry/analytics/`
- Removes the external `loft-sh/analytics-client` dependency from `go.mod`
- Replaces `k8s.io/klog` logging with the project's own `github.com/skevetter/log` logger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed external analytics client dependency
  * Migrated analytics system to internal implementation with event buffering and asynchronous batch uploads
  * Added configurable buffer capacity and upload interval throttling
  * Introduced no-op client option for flexible testing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->