### PR TITLE
fix: propagate git SSH signing key in daemon path and context in backhaul

### DIFF
--- a/pkg/client/clientimplementation/services.go
+++ b/pkg/client/clientimplementation/services.go
@@ -13,13 +13,14 @@ import (
 )
 
 type StartServicesDaemonOptions struct {
-	DevPodConfig *config.Config
-	Client       client.DaemonClient
-	SSHClient    *ssh.Client
-	User         string
-	Log          log.Logger
-	ForwardPorts bool
-	ExtraPorts   []string
+	DevPodConfig     *config.Config
+	Client           client.DaemonClient
+	SSHClient        *ssh.Client
+	User             string
+	Log              log.Logger
+	ForwardPorts     bool
+	ExtraPorts       []string
+	GitSSHSigningKey string
 }
 
 type credentialConfig struct {
@@ -54,6 +55,7 @@ func StartServicesDaemon(ctx context.Context, opts StartServicesDaemonOptions) e
 			ConfigureDockerCredentials:     credConfig.docker,
 			ConfigureGitCredentials:        credConfig.git,
 			ConfigureGitSSHSignatureHelper: credConfig.gitSSHSignature,
+			GitSSHSigningKey:               opts.GitSSHSigningKey,
 			Log:                            opts.Log,
 		},
 	)

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -236,13 +236,14 @@ func makeDaemonStartFunc(
 		err = clientimplementation.StartServicesDaemon(
 			ctx,
 			clientimplementation.StartServicesDaemonOptions{
-				DevPodConfig: params.DevPodConfig,
-				Client:       daemonClient,
-				SSHClient:    toolClient,
-				User:         params.User,
-				Log:          params.Log,
-				ForwardPorts: forwardPorts,
-				ExtraPorts:   extraPorts,
+				DevPodConfig:     params.DevPodConfig,
+				Client:           daemonClient,
+				SSHClient:        toolClient,
+				User:             params.User,
+				Log:              params.Log,
+				ForwardPorts:     forwardPorts,
+				ExtraPorts:       extraPorts,
+				GitSSHSigningKey: params.GitSSHSigningKey,
 			},
 		)
 		if err != nil {

--- a/pkg/tunnel/browser.go
+++ b/pkg/tunnel/browser.go
@@ -37,7 +37,7 @@ type BrowserTunnelParams struct {
 func StartBrowserTunnel(p BrowserTunnelParams) error {
 	if p.AuthSockID != "" {
 		go func() {
-			if err := SetupBackhaul(p.Client, p.AuthSockID, p.Logger); err != nil {
+			if err := SetupBackhaul(p.Ctx, p.Client, p.AuthSockID, p.Logger); err != nil {
 				p.Logger.Error("Failed to setup backhaul SSH connection: ", err)
 			}
 		}()
@@ -120,7 +120,12 @@ func runBrowserTunnelServices(
 }
 
 // SetupBackhaul sets up a long-running SSH connection for backhaul.
-func SetupBackhaul(client client2.BaseWorkspaceClient, authSockID string, logger log.Logger) error {
+func SetupBackhaul(
+	ctx context.Context,
+	client client2.BaseWorkspaceClient,
+	authSockID string,
+	logger log.Logger,
+) error {
 	execPath, err := os.Executable()
 	if err != nil {
 		return err
@@ -136,7 +141,7 @@ func SetupBackhaul(client client2.BaseWorkspaceClient, authSockID string, logger
 	}
 
 	//nolint:gosec // execPath is the current binary, arguments are controlled
-	backhaulCmd := exec.Command(
+	backhaulCmd := exec.CommandContext(ctx,
 		execPath,
 		"ssh",
 		"--agent-forwarding=true",
@@ -149,7 +154,7 @@ func SetupBackhaul(client client2.BaseWorkspaceClient, authSockID string, logger
 		client.Workspace(),
 		"--log-output=raw",
 		"--command",
-		"while true; do sleep 6000000; done",
+		"while true; do sleep 6000000; done", // sleep infinity is not available on all systems
 	)
 
 	if logger.GetLevel() == logrus.DebugLevel {
@@ -159,6 +164,7 @@ func SetupBackhaul(client client2.BaseWorkspaceClient, authSockID string, logger
 	logger.Info("Setting up backhaul SSH connection")
 
 	writer := logger.Writer(logrus.InfoLevel, false)
+	defer func() { _ = writer.Close() }()
 
 	backhaulCmd.Stdout = writer
 	backhaulCmd.Stderr = writer


### PR DESCRIPTION
## Summary

Fast follow from #719. Fixes two pre-existing issues surfaced during review:

- **GitSSHSigningKey not propagated in daemon path:** Daemon-based browser IDE sessions (e.g. DevPod Pro) silently dropped the SSH signing key, so git commit signing didn't work. The SSH tunnel path already handled this correctly. Adds `GitSSHSigningKey` to `StartServicesDaemonOptions` and propagates it from `makeDaemonStartFunc`.

- **SetupBackhaul not context-aware:** The backhaul SSH process (`devpod ssh --command "while true; do sleep 6000000; done"`) used `exec.Command` instead of `exec.CommandContext`, so it was orphaned when the browser session ended. Now uses the caller's context for proper cleanup.

Also restores a portability comment explaining why `while true; do sleep 6000000; done` is used instead of `sleep infinity` (not available on all systems), and adds a deferred `writer.Close()` in `SetupBackhaul`.