### PR TITLE
refactor: replace kballard/go-shellquote with shellescape

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/joho/godotenv v1.5.1
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/loft-sh/agentapi/v4 v4.8.1
 	github.com/loft-sh/api/v4 v4.4.0
 	github.com/loft-sh/apiserver v0.0.0-20260113122925-594495a02e96
@@ -197,6 +196,7 @@ require (
 	github.com/jsimonetti/rtnetlink v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/pkg/dockercredentials/dockercredentials.go
+++ b/pkg/dockercredentials/dockercredentials.go
@@ -7,10 +7,10 @@ import (
 	"runtime"
 	"strings"
 
+	"al.essio.dev/pkg/shellescape"
 	dockerconfig "github.com/containers/image/v5/pkg/docker/config"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/kballard/go-shellquote"
 	"github.com/skevetter/devpod/pkg/command"
 	pkgconfig "github.com/skevetter/devpod/pkg/config"
 	"github.com/skevetter/devpod/pkg/docker"
@@ -108,13 +108,13 @@ func configureCredentials(
 		)
 		helperContent = []byte(script)
 	} else {
-		cmd := shellquote.Join(
+		cmd := shellescape.QuoteCommand([]string{
 			binaryPath,
 			"agent",
 			"docker-credentials",
 			"--port",
 			fmt.Sprintf("%d", port),
-		)
+		})
 		helperContent = []byte(shebang + "\n" + cmd + ` "$@"` + "\n")
 	}
 

--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kballard/go-shellquote"
+	"al.essio.dev/pkg/shellescape"
 	"github.com/sirupsen/logrus"
 	"github.com/skevetter/devpod/pkg/command"
 	"github.com/skevetter/devpod/pkg/config"
@@ -212,7 +212,7 @@ func (o *VsCodeServer) buildExtensionCommand(binPath, extension string) *exec.Cm
 	args := []string{"--install-extension", extension}
 
 	if o.userName != "" {
-		cmd := shellquote.Join(append([]string{binPath}, args...)...)
+		cmd := shellescape.QuoteCommand(append([]string{binPath}, args...))
 		return exec.Command("su", o.userName, "-c", cmd)
 	}
 	return exec.Command(binPath, args...)

--- a/pkg/tunnel/services.go
+++ b/pkg/tunnel/services.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/docker/go-connections/nat"
-	"github.com/kballard/go-shellquote"
 	"github.com/loft-sh/api/v4/pkg/devpod"
 	"github.com/sirupsen/logrus"
 	"github.com/skevetter/devpod/pkg/agent"
@@ -130,8 +130,8 @@ func addGitSSHSigningKey(command string, explicitKey string, log log.Logger) str
 func buildCredentialsCommand(opts RunServicesOptions) string {
 	command := fmt.Sprintf(
 		"%s agent container credentials-server --user %s",
-		shellquote.Join(agent.ContainerDevPodHelperLocation),
-		shellquote.Join(opts.User),
+		shellescape.Quote(agent.ContainerDevPodHelperLocation),
+		shellescape.Quote(opts.User),
 	)
 	if opts.ConfigureGitCredentials {
 		command += " --configure-git-helper"


### PR DESCRIPTION
## Summary
- Replace all direct usages of the unmaintained `github.com/kballard/go-shellquote` with `al.essio.dev/pkg/shellescape`
- `shellescape` was already used elsewhere in the codebase; this makes it the sole shell-quoting library
- `go-shellquote` remains as an indirect dep via `AlecAivazis/survey/v2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and refactored shell command handling mechanisms for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->