### PR TITLE
feat: open IDE before postAttachCommand runs

### DIFF
--- a/cmd/agent/container/container.go
+++ b/cmd/agent/container/container.go
@@ -13,6 +13,7 @@ func NewContainerCmd(flags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	containerCmd.AddCommand(NewSetupContainerCmd(flags))
+	containerCmd.AddCommand(NewPostAttachCmd(flags))
 	containerCmd.AddCommand(NewDaemonCmd())
 	containerCmd.AddCommand(NewVSCodeAsyncCmd())
 	containerCmd.AddCommand(NewOpenVSCodeAsyncCmd())

--- a/cmd/agent/container/post_attach.go
+++ b/cmd/agent/container/post_attach.go
@@ -1,0 +1,61 @@
+//go:build !windows
+
+package container
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/skevetter/devpod/cmd/flags"
+	"github.com/skevetter/devpod/pkg/compress"
+	"github.com/skevetter/devpod/pkg/devcontainer/config"
+	"github.com/skevetter/devpod/pkg/devcontainer/setup"
+	"github.com/skevetter/log"
+	"github.com/spf13/cobra"
+)
+
+// PostAttachCmd runs postAttachCommand hooks as a detached background process.
+type PostAttachCmd struct {
+	*flags.GlobalFlags
+	SetupInfo string
+}
+
+// NewPostAttachCmd creates a new command.
+func NewPostAttachCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &PostAttachCmd{
+		GlobalFlags: flags,
+	}
+	postAttachCmd := &cobra.Command{
+		Use:   "post-attach",
+		Short: "Runs postAttachCommand lifecycle hooks",
+		Args:  cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(cobraCmd.Context())
+		},
+	}
+	postAttachCmd.Flags().StringVar(&cmd.SetupInfo, "setup-info", "", "The container setup info")
+	_ = postAttachCmd.MarkFlagRequired("setup-info")
+	return postAttachCmd
+}
+
+// Run runs the postAttachCommand lifecycle hooks.
+func (cmd *PostAttachCmd) Run(ctx context.Context) error {
+	logger := log.Default
+
+	decompressed, err := compress.Decompress(cmd.SetupInfo)
+	if err != nil {
+		return err
+	}
+
+	setupInfo := &config.Result{}
+	if err := json.Unmarshal([]byte(decompressed), setupInfo); err != nil {
+		return err
+	}
+
+	logger.Debugf("running postAttachCommand hooks")
+	if err := setup.RunPostAttachHooks(ctx, setupInfo, logger); err != nil {
+		logger.Errorf("postAttachCommand failed: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/agent/container/post_attach_windows.go
+++ b/cmd/agent/container/post_attach_windows.go
@@ -3,6 +3,8 @@
 package container
 
 import (
+	"fmt"
+
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +15,7 @@ func NewPostAttachCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Runs postAttachCommand lifecycle hooks",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			panic("Windows Containers are not supported")
+			return fmt.Errorf("Windows Containers are not supported")
 		},
 	}
 }

--- a/cmd/agent/container/post_attach_windows.go
+++ b/cmd/agent/container/post_attach_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package container
+
+import (
+	"github.com/skevetter/devpod/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+func NewPostAttachCmd(flags *flags.GlobalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "post-attach",
+		Short: "Runs postAttachCommand lifecycle hooks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			panic("Windows Containers are not supported")
+		},
+	}
+}

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -203,18 +203,15 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		return err
 	}
 
-	// Send result to client so IDE can open while postAttachCommand runs
-	if err := cmd.sendSetupResult(sctx.ctx, sctx.setupInfo, sctx.tunnelClient); err != nil {
-		return err
+	// Launch postAttachCommand as a detached background process before sending
+	// the result. Once sendSetupResult returns, the client tears down the SSH
+	// tunnel which kills this process, so postAttach must already be running
+	// independently.
+	if err := cmd.startPostAttachHooks(sctx); err != nil {
+		sctx.logger.Errorf("failed to start postAttachCommand: %v", err)
 	}
 
-	// Run postAttachCommand after result is sent — errors are logged, not propagated,
-	// because the IDE is already opening and the user can see output in the terminal.
-	if err := setup.SetupContainerPostAttach(sctx.ctx, cfg); err != nil {
-		sctx.logger.Errorf("postAttachCommand failed: %v", err)
-	}
-
-	return nil
+	return cmd.sendSetupResult(sctx.ctx, sctx.setupInfo, sctx.tunnelClient)
 }
 
 func (cmd *SetupContainerCmd) initializeTunnelClient(
@@ -378,6 +375,30 @@ func (cmd *SetupContainerCmd) startContainerDaemon(
 			"daemon",
 			"--timeout",
 			workspaceInfo.ContainerTimeout,
+		), nil
+	})
+}
+
+func (cmd *SetupContainerCmd) startPostAttachHooks(sctx *setupContext) error {
+	if len(sctx.setupInfo.MergedConfig.PostAttachCommands) == 0 {
+		return nil
+	}
+
+	return command.StartBackgroundOnce("devpod.post-attach", func() (*exec.Cmd, error) {
+		sctx.logger.Debugf("starting postAttachCommand as background process")
+		binaryPath, err := os.Executable()
+		if err != nil {
+			return nil, err
+		}
+
+		//nolint:gosec // binaryPath is from os.Executable(), not user input
+		return exec.Command(
+			binaryPath,
+			"agent",
+			"container",
+			"post-attach",
+			"--setup-info",
+			cmd.SetupInfo,
 		), nil
 	})
 }

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -121,11 +121,7 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := cmd.finalizeSetup(sctx); err != nil {
-		return err
-	}
-
-	return cmd.sendSetupResult(ctx, setupInfo, tunnelClient)
+	return cmd.finalizeSetup(sctx)
 }
 
 func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
@@ -186,15 +182,16 @@ func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
 }
 
 func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
-	err := setup.SetupContainer(sctx.ctx, &setup.ContainerSetupConfig{
+	cfg := &setup.ContainerSetupConfig{
 		SetupInfo:         sctx.setupInfo,
 		ExtraWorkspaceEnv: sctx.workspaceInfo.CLIOptions.WorkspaceEnv,
 		ChownProjects:     cmd.ChownWorkspace,
 		PlatformOptions:   &sctx.workspaceInfo.CLIOptions.Platform,
 		TunnelClient:      sctx.tunnelClient,
 		Log:               sctx.logger,
-	})
-	if err != nil {
+	}
+
+	if err := setup.SetupContainerPreAttach(sctx.ctx, cfg); err != nil {
 		return err
 	}
 
@@ -202,7 +199,22 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		return err
 	}
 
-	return cmd.startContainerDaemon(sctx.workspaceInfo, sctx.logger)
+	if err := cmd.startContainerDaemon(sctx.workspaceInfo, sctx.logger); err != nil {
+		return err
+	}
+
+	// Send result to client so IDE can open while postAttachCommand runs
+	if err := cmd.sendSetupResult(sctx.ctx, sctx.setupInfo, sctx.tunnelClient); err != nil {
+		return err
+	}
+
+	// Run postAttachCommand after result is sent — errors are logged, not propagated,
+	// because the IDE is already opening and the user can see output in the terminal.
+	if err := setup.SetupContainerPostAttach(sctx.ctx, cfg); err != nil {
+		sctx.logger.Errorf("postAttachCommand failed: %v", err)
+	}
+
+	return nil
 }
 
 func (cmd *SetupContainerCmd) initializeTunnelClient(

--- a/cmd/agent/container/setup_windows.go
+++ b/cmd/agent/container/setup_windows.go
@@ -3,6 +3,8 @@
 package container
 
 import (
+	"fmt"
+
 	"github.com/skevetter/devpod/cmd/flags"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +15,7 @@ func NewSetupContainerCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Sets up a container",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			panic("Windows Containers are not supported")
+			return fmt.Errorf("Windows Containers are not supported")
 		},
 	}
 }

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -324,7 +324,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("postStartDone"),
 				"postStartCommand should have completed before devpod up returned")
 
-			// postAttachCommand should NOT have completed yet (it sleeps 5s)
+			// postAttachCommand should NOT have completed yet (it sleeps 15s)
 			_, err = dtc.execSSH(ctx, tempDir, "cat $HOME/post-attach.out")
 			gomega.Expect(err).To(gomega.HaveOccurred(),
 				"postAttachCommand should still be running when devpod up returns")

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/onsi/ginkgo/v2"
@@ -302,6 +303,43 @@ var _ = ginkgo.Describe(
 			lines = strings.Count(strings.TrimSpace(out), "\n") + 1
 			gomega.Expect(lines).To(gomega.Equal(2),
 				"postStartCommand should have run again after restart")
+		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
+		ginkgo.It("IDE accessible before postAttachCommand completes", func(ctx context.Context) {
+			tempDir, err := setupWorkspace(
+				"tests/up/testdata/docker-post-attach-nonblocking",
+				dtc.initialDir,
+				dtc.f,
+			)
+			framework.ExpectNoError(err)
+
+			// devpod up with --ide none returns when IDE would open,
+			// which should now be BEFORE postAttachCommand finishes
+			err = dtc.f.DevPodUp(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			// postStartCommand should have completed (runs before result is sent)
+			out, err := dtc.execSSH(ctx, tempDir, "cat $HOME/post-start.out")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("postStartDone"),
+				"postStartCommand should have completed before devpod up returned")
+
+			// postAttachCommand should NOT have completed yet (it sleeps 5s)
+			_, err = dtc.execSSH(ctx, tempDir, "cat $HOME/post-attach.out")
+			gomega.Expect(err).To(gomega.HaveOccurred(),
+				"postAttachCommand should still be running when devpod up returns")
+
+			// Wait for postAttachCommand to finish and verify it does complete
+			gomega.Eventually(func() string {
+				out, err := dtc.execSSH(ctx, tempDir, "cat $HOME/post-attach.out 2>/dev/null")
+				if err != nil {
+					return ""
+				}
+				return strings.TrimSpace(out)
+			}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(
+				gomega.Equal("postAttachDone"),
+				"postAttachCommand should eventually complete in the background",
+			)
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
 		ginkgo.It("multi devcontainer selection", func(ctx context.Context) {

--- a/e2e/tests/up/testdata/docker-post-attach-nonblocking/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-post-attach-nonblocking/.devcontainer.json
@@ -1,5 +1,5 @@
 {
   "image": "mcr.microsoft.com/devcontainers/go:1",
   "postStartCommand": "echo postStartDone > $HOME/post-start.out",
-  "postAttachCommand": "sleep 5 && echo postAttachDone > $HOME/post-attach.out"
+  "postAttachCommand": "sleep 15 && echo postAttachDone > $HOME/post-attach.out"
 }

--- a/e2e/tests/up/testdata/docker-post-attach-nonblocking/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-post-attach-nonblocking/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "postStartCommand": "echo postStartDone > $HOME/post-start.out",
+  "postAttachCommand": "sleep 5 && echo postAttachDone > $HOME/post-attach.out"
+}

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -21,15 +21,6 @@ import (
 	"github.com/skevetter/log"
 )
 
-// RunLifecycleHooks runs all lifecycle hooks synchronously.
-// This is the original behavior kept for backward compatibility.
-func RunLifecycleHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
-	if err := RunPreAttachHooks(ctx, setupInfo, log); err != nil {
-		return err
-	}
-	return RunPostAttachHooks(ctx, setupInfo, log)
-}
-
 // RunPreAttachHooks runs lifecycle hooks up to and including postStartCommand.
 // These must complete before the IDE can be opened.
 func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -21,7 +21,18 @@ import (
 	"github.com/skevetter/log"
 )
 
+// RunLifecycleHooks runs all lifecycle hooks synchronously.
+// This is the original behavior kept for backward compatibility.
 func RunLifecycleHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
+	if err := RunPreAttachHooks(ctx, setupInfo, log); err != nil {
+		return err
+	}
+	return RunPostAttachHooks(ctx, setupInfo, log)
+}
+
+// RunPreAttachHooks runs lifecycle hooks up to and including postStartCommand.
+// These must complete before the IDE can be opened.
+func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
 	mergedConfig := setupInfo.MergedConfig
 	remoteUser := config.GetRemoteUser(setupInfo)
 	probedEnv, err := config.ProbeUserEnv(ctx, mergedConfig.UserEnvProbe, remoteUser, log)
@@ -61,6 +72,23 @@ func RunLifecycleHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// RunPostAttachHooks runs postAttachCommand only.
+// These run after the IDE has been opened and can be long-running.
+func RunPostAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
+	mergedConfig := setupInfo.MergedConfig
+	remoteUser := config.GetRemoteUser(setupInfo)
+	probedEnv, err := config.ProbeUserEnv(ctx, mergedConfig.UserEnvProbe, remoteUser, log)
+	if err != nil {
+		log.WithFields(logrus.Fields{"error": err}).
+			Error("failed to probe environment, this might lead to an incomplete setup of your workspace")
+	}
+	remoteEnv := mergeRemoteEnv(mergedConfig.RemoteEnv, probedEnv, remoteUser)
+
+	workspaceFolder := setupInfo.SubstitutionContext.ContainerWorkspaceFolder
 
 	// run always when attaching to the container
 	err = run(mergedConfig.PostAttachCommands, remoteUser, workspaceFolder, remoteEnv,

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -21,9 +21,18 @@ import (
 	"github.com/skevetter/log"
 )
 
-// RunPreAttachHooks runs lifecycle hooks up to and including postStartCommand.
-// These must complete before the IDE can be opened.
-func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
+// lifecycleEnv holds the resolved environment for running lifecycle hooks.
+type lifecycleEnv struct {
+	remoteUser      string
+	workspaceFolder string
+	remoteEnv       map[string]string
+}
+
+func resolveLifecycleEnv(
+	ctx context.Context,
+	setupInfo *config.Result,
+	log log.Logger,
+) lifecycleEnv {
 	mergedConfig := setupInfo.MergedConfig
 	remoteUser := config.GetRemoteUser(setupInfo)
 	probedEnv, err := config.ProbeUserEnv(ctx, mergedConfig.UserEnvProbe, remoteUser, log)
@@ -31,36 +40,63 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 		log.WithFields(logrus.Fields{"error": err}).
 			Error("failed to probe environment, this might lead to an incomplete setup of your workspace")
 	}
-	remoteEnv := mergeRemoteEnv(mergedConfig.RemoteEnv, probedEnv, remoteUser)
 
-	workspaceFolder := setupInfo.SubstitutionContext.ContainerWorkspaceFolder
+	return lifecycleEnv{
+		remoteUser:      remoteUser,
+		workspaceFolder: setupInfo.SubstitutionContext.ContainerWorkspaceFolder,
+		remoteEnv:       mergeRemoteEnv(mergedConfig.RemoteEnv, probedEnv, remoteUser),
+	}
+}
+
+// RunPreAttachHooks runs lifecycle hooks up to and including postStartCommand.
+// These must complete before the IDE can be opened.
+func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
+	env := resolveLifecycleEnv(ctx, setupInfo, log)
 	containerDetails := setupInfo.ContainerDetails
+	mergedConfig := setupInfo.MergedConfig
 
 	// only run once per container run
-	err = run(mergedConfig.OnCreateCommands, remoteUser, workspaceFolder, remoteEnv,
-		"onCreateCommands", containerDetails.Created, log)
-	if err != nil {
+	if err := run(mergedConfig.OnCreateCommands, env.remoteUser, env.workspaceFolder, env.remoteEnv,
+		"onCreateCommands", containerDetails.Created, log); err != nil {
 		return err
 	}
 
 	// TODO: rerun when contents changed
-	err = run(mergedConfig.UpdateContentCommands, remoteUser, workspaceFolder, remoteEnv,
-		"updateContentCommands", containerDetails.Created, log)
-	if err != nil {
+	if err := run(
+		mergedConfig.UpdateContentCommands,
+		env.remoteUser,
+		env.workspaceFolder,
+		env.remoteEnv,
+		"updateContentCommands",
+		containerDetails.Created,
+		log,
+	); err != nil {
 		return err
 	}
 
 	// only run once per container run
-	err = run(mergedConfig.PostCreateCommands, remoteUser, workspaceFolder, remoteEnv,
-		"postCreateCommands", containerDetails.Created, log)
-	if err != nil {
+	if err := run(
+		mergedConfig.PostCreateCommands,
+		env.remoteUser,
+		env.workspaceFolder,
+		env.remoteEnv,
+		"postCreateCommands",
+		containerDetails.Created,
+		log,
+	); err != nil {
 		return err
 	}
 
 	// run when the container was restarted
-	err = run(mergedConfig.PostStartCommands, remoteUser, workspaceFolder, remoteEnv,
-		"postStartCommands", containerDetails.State.StartedAt, log)
-	if err != nil {
+	if err := run(
+		mergedConfig.PostStartCommands,
+		env.remoteUser,
+		env.workspaceFolder,
+		env.remoteEnv,
+		"postStartCommands",
+		containerDetails.State.StartedAt,
+		log,
+	); err != nil {
 		return err
 	}
 
@@ -70,25 +106,18 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 // RunPostAttachHooks runs postAttachCommand only.
 // These run after the IDE has been opened and can be long-running.
 func RunPostAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
-	mergedConfig := setupInfo.MergedConfig
-	remoteUser := config.GetRemoteUser(setupInfo)
-	probedEnv, err := config.ProbeUserEnv(ctx, mergedConfig.UserEnvProbe, remoteUser, log)
-	if err != nil {
-		log.WithFields(logrus.Fields{"error": err}).
-			Error("failed to probe environment, this might lead to an incomplete setup of your workspace")
-	}
-	remoteEnv := mergeRemoteEnv(mergedConfig.RemoteEnv, probedEnv, remoteUser)
-
-	workspaceFolder := setupInfo.SubstitutionContext.ContainerWorkspaceFolder
+	env := resolveLifecycleEnv(ctx, setupInfo, log)
 
 	// run always when attaching to the container
-	err = run(mergedConfig.PostAttachCommands, remoteUser, workspaceFolder, remoteEnv,
-		"postAttachCommands", "", log)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return run(
+		setupInfo.MergedConfig.PostAttachCommands,
+		env.remoteUser,
+		env.workspaceFolder,
+		env.remoteEnv,
+		"postAttachCommands",
+		"",
+		log,
+	)
 }
 
 func run(

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -82,7 +82,7 @@ func (s *LifecycleHookTestSuite) TestSymlinkWithQuotes() {
 	assert.NotEqual(s.T(), byte('"'), target[len(target)-1])
 }
 
-func (s *LifecycleHookTestSuite) TestRunPreAttachHooksDoesNotRunPostAttach() {
+func (s *LifecycleHookTestSuite) TestLifecycleHooksNoOpWithEmptyConfig() {
 	ctx := context.Background()
 	result := &config.Result{
 		MergedConfig: &config.MergedDevContainerConfig{},

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -1,11 +1,14 @@
 package setup
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"os/user"
 	"testing"
 
+	"github.com/skevetter/devpod/pkg/devcontainer/config"
+	"github.com/skevetter/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -77,6 +80,26 @@ func (s *LifecycleHookTestSuite) TestSymlinkWithQuotes() {
 	s.Require().NotEmpty(target, "symlink target should not be empty")
 	assert.NotEqual(s.T(), byte('"'), target[0])
 	assert.NotEqual(s.T(), byte('"'), target[len(target)-1])
+}
+
+func (s *LifecycleHookTestSuite) TestRunPreAttachHooksDoesNotRunPostAttach() {
+	ctx := context.Background()
+	result := &config.Result{
+		MergedConfig: &config.MergedDevContainerConfig{},
+		ContainerDetails: &config.ContainerDetails{
+			State: config.ContainerDetailsState{},
+		},
+		SubstitutionContext: &config.SubstitutionContext{
+			ContainerWorkspaceFolder: "/workspaces/test",
+		},
+	}
+
+	// Both functions should return nil with empty config (no commands to run)
+	err := RunPreAttachHooks(ctx, result, log.Default)
+	assert.NoError(s.T(), err)
+
+	err = RunPostAttachHooks(ctx, result, log.Default)
+	assert.NoError(s.T(), err)
 }
 
 func TestLifecycleHookTestSuite(t *testing.T) {

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -38,15 +38,6 @@ type ContainerSetupConfig struct {
 	Log               log.Logger
 }
 
-// SetupContainer runs the full container setup including all lifecycle hooks.
-// This is the original behavior kept for backward compatibility.
-func SetupContainer(ctx context.Context, cfg *ContainerSetupConfig) error {
-	if err := SetupContainerPreAttach(ctx, cfg); err != nil {
-		return err
-	}
-	return SetupContainerPostAttach(ctx, cfg)
-}
-
 // SetupContainerPreAttach runs container setup up to and including postStartCommand.
 // After this returns, the workspace is ready for IDE access.
 func SetupContainerPreAttach(ctx context.Context, cfg *ContainerSetupConfig) error {

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -38,7 +38,18 @@ type ContainerSetupConfig struct {
 	Log               log.Logger
 }
 
+// SetupContainer runs the full container setup including all lifecycle hooks.
+// This is the original behavior kept for backward compatibility.
 func SetupContainer(ctx context.Context, cfg *ContainerSetupConfig) error {
+	if err := SetupContainerPreAttach(ctx, cfg); err != nil {
+		return err
+	}
+	return SetupContainerPostAttach(ctx, cfg)
+}
+
+// SetupContainerPreAttach runs container setup up to and including postStartCommand.
+// After this returns, the workspace is ready for IDE access.
+func SetupContainerPreAttach(ctx context.Context, cfg *ContainerSetupConfig) error {
 	if err := validateContainerSetupConfig(cfg); err != nil {
 		return err
 	}
@@ -55,9 +66,21 @@ func SetupContainer(ctx context.Context, cfg *ContainerSetupConfig) error {
 
 	setupOptionalFeatures(ctx, cfg)
 
-	cfg.Log.Debugf("running lifecycle hooks")
-	if err := RunLifecycleHooks(ctx, cfg.SetupInfo, cfg.Log); err != nil {
-		return fmt.Errorf("lifecycle hooks: %w", err)
+	cfg.Log.Debugf("running pre-attach lifecycle hooks")
+	if err := RunPreAttachHooks(ctx, cfg.SetupInfo, cfg.Log); err != nil {
+		return fmt.Errorf("lifecycle hooks pre-attach: %w", err)
+	}
+
+	cfg.Log.Debugf("pre-attach setup completed")
+	return nil
+}
+
+// SetupContainerPostAttach runs postAttachCommand only.
+// Called after the IDE has been opened.
+func SetupContainerPostAttach(ctx context.Context, cfg *ContainerSetupConfig) error {
+	cfg.Log.Debugf("running post-attach lifecycle hooks")
+	if err := RunPostAttachHooks(ctx, cfg.SetupInfo, cfg.Log); err != nil {
+		return fmt.Errorf("lifecycle hooks post-attach: %w", err)
 	}
 
 	cfg.Log.Debugf("devcontainer setup completed")


### PR DESCRIPTION
- Splits lifecycle hook execution into pre-attach (onCreate → postStart) and post-attach (postAttach only) phases
- Sends the setup result to the client **before** running `postAttachCommand`, unblocking IDE opening
- `postAttachCommand` errors are logged but don't block IDE access
- Aligns with the [devcontainer spec](https://containers.dev/implementors/json_reference/) which defines `postAttachCommand` as running *after* tool attachment

Fixes #708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a post-attach command and separate post-attach lifecycle phase so post-attach hooks run independently (non-blocking/background).

* **Behavior Changes**
  * Setup now runs in pre-attach and post-attach phases, allowing the IDE to become accessible before post-attach hooks finish.

* **Bug Fixes**
  * Windows builds report post-attach as unsupported and return an error instead of crashing.

* **Tests**
  * New end-to-end test verifies IDE is accessible before post-attach completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->