### PR TITLE
test(e2e): retry DevPodUp on transient Docker registry errors

### DIFF
--- a/e2e/framework/command.go
+++ b/e2e/framework/command.go
@@ -63,7 +63,12 @@ func (f *Framework) DevPodUpStreams(
 	upArgs := []string{"up", "--ide", "none", workspace}
 	upArgs = append(upArgs, additionalArgs...)
 
-	stdout, stderr, err := f.ExecCommandCapture(ctx, upArgs)
+	stdout, stderr, err := execWithDockerRetry(
+		ctx,
+		func(ctx context.Context) (string, string, error) {
+			return f.ExecCommandCapture(ctx, upArgs)
+		},
+	)
 	if err != nil {
 		return stdout, stderr, fmt.Errorf("devpod up failed: %s", err.Error())
 	}
@@ -76,7 +81,9 @@ func (f *Framework) DevPodUpWithIDE(ctx context.Context, additionalArgs ...strin
 	upArgs := []string{"up", "--debug"}
 	upArgs = append(upArgs, additionalArgs...)
 
-	_, _, err := f.ExecCommandCapture(ctx, upArgs)
+	_, _, err := execWithDockerRetry(ctx, func(ctx context.Context) (string, string, error) {
+		return f.ExecCommandCapture(ctx, upArgs)
+	})
 	if err != nil {
 		return fmt.Errorf("devpod up failed: %s", err.Error())
 	}
@@ -98,7 +105,9 @@ func (f *Framework) DevPodUp(ctx context.Context, additionalArgs ...string) erro
 	upArgs := []string{"up", "--debug", "--ide", "none"}
 	upArgs = append(upArgs, additionalArgs...)
 
-	_, _, err := f.ExecCommandCapture(ctx, upArgs)
+	_, _, err := execWithDockerRetry(ctx, func(ctx context.Context) (string, string, error) {
+		return f.ExecCommandCapture(ctx, upArgs)
+	})
 	if err != nil {
 		return fmt.Errorf("devpod up failed: %s", err.Error())
 	}
@@ -109,7 +118,9 @@ func (f *Framework) DevPodUpRecreate(ctx context.Context, additionalArgs ...stri
 	upArgs := []string{"up", "--recreate", "--debug", "--ide", "none"}
 	upArgs = append(upArgs, additionalArgs...)
 
-	_, _, err := f.ExecCommandCapture(ctx, upArgs)
+	_, _, err := execWithDockerRetry(ctx, func(ctx context.Context) (string, string, error) {
+		return f.ExecCommandCapture(ctx, upArgs)
+	})
 	if err != nil {
 		return fmt.Errorf("devpod up --recreate failed: %s", err.Error())
 	}
@@ -120,7 +131,9 @@ func (f *Framework) DevPodUpReset(ctx context.Context, additionalArgs ...string)
 	upArgs := []string{"up", "--reset", "--debug", "--ide", "none"}
 	upArgs = append(upArgs, additionalArgs...)
 
-	_, _, err := f.ExecCommandCapture(ctx, upArgs)
+	_, _, err := execWithDockerRetry(ctx, func(ctx context.Context) (string, string, error) {
+		return f.ExecCommandCapture(ctx, upArgs)
+	})
 	if err != nil {
 		return fmt.Errorf("devpod up --reset failed: %s", err.Error())
 	}

--- a/e2e/framework/retry.go
+++ b/e2e/framework/retry.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,9 +12,9 @@ import (
 )
 
 // dockerPullBackoff defines retry timing for transient Docker registry errors.
-// 3 retries: ~30s, ~60s, ~120s — aligns with Docker Hub rate limit windows.
+// 4 total attempts (1 initial + 3 retries) with waits of ~30s, ~60s, ~120s.
 var dockerPullBackoff = wait.Backoff{
-	Steps:    3,
+	Steps:    4,
 	Duration: 30 * time.Second,
 	Factor:   2.0,
 	Jitter:   0.1,
@@ -33,8 +34,9 @@ var retryableDockerPatterns = []string{
 // isRetryableDockerError returns true if stderr contains a transient Docker
 // registry error (rate limits, timeouts, connection resets).
 func isRetryableDockerError(stderr string) bool {
+	lower := strings.ToLower(stderr)
 	for _, pattern := range retryableDockerPatterns {
-		if strings.Contains(stderr, pattern) {
+		if strings.Contains(lower, strings.ToLower(pattern)) {
 			return true
 		}
 	}
@@ -68,6 +70,9 @@ func execWithDockerRetry(
 			return false, lastErr // non-retryable, stop immediately
 		},
 	)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return lastStdout, lastStderr, err
+	}
 	if err != nil && lastErr != nil {
 		return lastStdout, lastStderr, fmt.Errorf("after %d attempts: %w", attempt, lastErr)
 	}

--- a/e2e/framework/retry.go
+++ b/e2e/framework/retry.go
@@ -1,0 +1,75 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// dockerPullBackoff defines retry timing for transient Docker registry errors.
+// 3 retries: ~30s, ~60s, ~120s — aligns with Docker Hub rate limit windows.
+var dockerPullBackoff = wait.Backoff{
+	Steps:    3,
+	Duration: 30 * time.Second,
+	Factor:   2.0,
+	Jitter:   0.1,
+}
+
+// retryableDockerPatterns are stderr substrings indicating a transient Docker
+// registry error that is worth retrying.
+var retryableDockerPatterns = []string{
+	"TOOMANYREQUESTS",
+	"rate limit",
+	"TLS handshake timeout",
+	"i/o timeout",
+	"connection reset by peer",
+	"503 Service Unavailable",
+}
+
+// isRetryableDockerError returns true if stderr contains a transient Docker
+// registry error (rate limits, timeouts, connection resets).
+func isRetryableDockerError(stderr string) bool {
+	for _, pattern := range retryableDockerPatterns {
+		if strings.Contains(stderr, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// execWithDockerRetry runs fn and retries if stderr indicates a transient
+// Docker registry error. Returns the last stdout, stderr, and error.
+func execWithDockerRetry(
+	ctx context.Context,
+	fn func(ctx context.Context) (stdout, stderr string, err error),
+) (string, string, error) {
+	var lastStdout, lastStderr string
+	var lastErr error
+	attempt := 0
+
+	err := wait.ExponentialBackoffWithContext(ctx, dockerPullBackoff,
+		func(ctx context.Context) (bool, error) {
+			attempt++
+			lastStdout, lastStderr, lastErr = fn(ctx)
+			if lastErr == nil {
+				return true, nil // success
+			}
+			if isRetryableDockerError(lastStderr) {
+				ginkgo.GinkgoWriter.Printf(
+					"[retry] attempt %d failed with transient Docker error, retrying: %s\n",
+					attempt, lastErr,
+				)
+				return false, nil // retry
+			}
+			return false, lastErr // non-retryable, stop immediately
+		},
+	)
+	if err != nil && lastErr != nil {
+		return lastStdout, lastStderr, fmt.Errorf("after %d attempts: %w", attempt, lastErr)
+	}
+	return lastStdout, lastStderr, err
+}

--- a/e2e/framework/retry_test.go
+++ b/e2e/framework/retry_test.go
@@ -1,0 +1,42 @@
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRetryableDockerError_RateLimit(t *testing.T) {
+	stderr := `GET https://index.docker.io/v2/library/ubuntu/manifests/latest: ` +
+		`TOOMANYREQUESTS: You have reached your unauthenticated pull rate limit.`
+	assert.True(t, isRetryableDockerError(stderr))
+}
+
+func TestIsRetryableDockerError_Timeout(t *testing.T) {
+	stderr := `Get "https://registry-1.docker.io/v2/": net/http: TLS handshake timeout`
+	assert.True(t, isRetryableDockerError(stderr))
+}
+
+func TestIsRetryableDockerError_IOTimeout(t *testing.T) {
+	stderr := `Get "https://registry-1.docker.io/v2/library/ubuntu/manifests/latest": i/o timeout`
+	assert.True(t, isRetryableDockerError(stderr))
+}
+
+func TestIsRetryableDockerError_ConnectionReset(t *testing.T) {
+	stderr := `error pulling image: read tcp 10.0.0.1:443: read: connection reset by peer`
+	assert.True(t, isRetryableDockerError(stderr))
+}
+
+func TestIsRetryableDockerError_ServiceUnavailable(t *testing.T) {
+	stderr := `received unexpected HTTP status: 503 Service Unavailable`
+	assert.True(t, isRetryableDockerError(stderr))
+}
+
+func TestIsRetryableDockerError_RealFailure(t *testing.T) {
+	stderr := `error resolving dockerfile: dockerfile not found`
+	assert.False(t, isRetryableDockerError(stderr))
+}
+
+func TestIsRetryableDockerError_Empty(t *testing.T) {
+	assert.False(t, isRetryableDockerError(""))
+}


### PR DESCRIPTION
## Summary
- Adds retry-with-backoff to all `DevPodUp*` E2E framework commands so transient Docker Hub errors don't cause false test failures
- Detects rate limits (`TOOMANYREQUESTS`), TLS handshake timeouts, i/o timeouts, connection resets, and 503 errors
- Uses `k8s.io/apimachinery/pkg/util/wait.ExponentialBackoffWithContext` for exponential backoff (3 retries: ~30s, ~60s, ~120s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced reliability of `devpod up` command by adding automatic retry logic for transient Docker registry failures, including rate limiting, network timeouts, connection resets, and temporary service unavailability errors.

* **Tests**
  * Added comprehensive test coverage for Docker failure detection and retry behavior validation across multiple failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->