### PR TITLE
fix(ssh): skip file path signing keys in GPG agent forwarding

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -769,7 +769,11 @@ func (cmd *SSHCmd) setupGPGAgent(
 // (SSH signing keys are handled by the separate SSH signature helper).
 func gpgSigningKey(log log.Logger) string {
 	format, err := exec.Command("git", "config", "--get", "gpg.format").Output()
-	if err == nil && strings.TrimSpace(string(format)) == "ssh" {
+	formatStr := ""
+	if err == nil {
+		formatStr = strings.TrimSpace(string(format))
+	}
+	if formatStr == "ssh" {
 		log.Debugf(
 			"[GPG] gpg.format is ssh, skipping GPG signing key (handled by SSH signing helper)",
 		)
@@ -783,6 +787,18 @@ func gpgSigningKey(log log.Logger) string {
 	}
 
 	result := strings.TrimSpace(string(key))
+
+	// GPG key IDs are hex fingerprints, not file paths. If the signing key
+	// looks like a file path and the format isn't x509 (which legitimately
+	// uses certificate file paths via gpgsm), it's an SSH key.
+	if (strings.HasPrefix(result, "/") || strings.HasPrefix(result, "~")) && formatStr != "x509" {
+		log.Debugf(
+			"[GPG] signing key %s looks like a file path, skipping (not a GPG key ID)",
+			result,
+		)
+		return ""
+	}
+
 	log.Debugf("[GPG] detected git sign key %s", result)
 	return result
 }

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -45,3 +45,15 @@ func TestGpgSigningKey_X509Format_Returned(t *testing.T) {
 	result := gpgSigningKey(log.Discard)
 	assert.Equal(t, "/path/to/cert", result)
 }
+
+func TestGpgSigningKey_SSHKeyPath_Skipped(t *testing.T) {
+	writeGitConfig(t, "[user]\n\tsigningKey = /home/user/.ssh/id_ed25519.pub\n")
+	result := gpgSigningKey(log.Discard)
+	assert.Empty(t, result)
+}
+
+func TestGpgSigningKey_TildeKeyPath_Skipped(t *testing.T) {
+	writeGitConfig(t, "[user]\n\tsigningKey = ~/.ssh/id_ed25519.pub\n")
+	result := gpgSigningKey(log.Discard)
+	assert.Empty(t, result)
+}


### PR DESCRIPTION
- When `user.signingKey` is a file path (starts with `/` or `~`) and `gpg.format` is not explicitly `ssh` or `x509`, skip GPG agent forwarding — the key is an SSH key, not a GPG hex fingerprint
- Handles the case where users set an SSH key path in `user.signingKey` without setting `gpg.format = ssh`
- Preserves x509 certificate path behavior (gpgsm legitimately uses file paths)

Closes #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPG/SSH signing key validation to detect filesystem paths (both absolute and tilde-prefixed) and skip them in specific scenarios.
  * Enhanced signing key processing to return empty values instead of passing through potentially invalid configuration entries.

* **Tests**
  * Added test coverage validating behavior for absolute and tilde-prefixed paths in signing key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->