### PR TITLE
Add support for git includIf config

### DIFF
--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -166,7 +166,7 @@ func configureGitUserLocally(
 	client tunnel.TunnelClient,
 ) error {
 	// get local credentials
-	localGitUser, err := gitcredentials.GetUser(userName)
+	localGitUser, err := gitcredentials.GetUser(userName, "")
 	if err != nil {
 		return err
 	} else if localGitUser.Name != "" && localGitUser.Email != "" {

--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -194,8 +194,10 @@ func configureGitUserLocally(
 		gitUser.Email = ""
 	}
 
-	// set git user
-	err = gitcredentials.SetUser(userName, gitUser)
+	// set git user — credentials server already runs as userName, so pass
+	// empty string to avoid "su <user>" which requires a password for
+	// non-root users and fails inside the container.
+	err = gitcredentials.SetUser("", gitUser)
 	if err != nil {
 		return fmt.Errorf("set git user & email: %w", err)
 	}

--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -194,10 +194,8 @@ func configureGitUserLocally(
 		gitUser.Email = ""
 	}
 
-	// set git user — credentials server already runs as userName, so pass
-	// empty string to avoid "su <user>" which requires a password for
-	// non-root users and fails inside the container.
-	err = gitcredentials.SetUser("", gitUser)
+	// set git user
+	err = gitcredentials.SetUser(userName, gitUser)
 	if err != nil {
 		return fmt.Errorf("set git user & email: %w", err)
 	}

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"net"
 	"os"
@@ -393,107 +392,6 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			gomega.Expect(combined).NotTo(
 				gomega.ContainSubstring("invalid character"),
 				"error should not contain JSON parse errors — error messages must be human-readable",
-			)
-		},
-	)
-
-	ginkgo.It(
-		"should forward git includeIf-resolved user identity into the devcontainer",
-		ginkgo.SpecTimeout(7*time.Minute),
-		func(ctx ginkgo.SpecContext) {
-			tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
-			framework.ExpectNoError(err)
-
-			f := framework.NewDefaultFramework(initialDir + "/bin")
-			_ = f.DevPodProviderAdd(ctx, "docker")
-			err = f.DevPodProviderUse(ctx, "docker")
-			framework.ExpectNoError(err)
-
-			ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
-				_ = f.DevPodWorkspaceDelete(cleanupCtx, tempDir)
-				framework.CleanupTempDir(initialDir, tempDir)
-			})
-
-			// git init is required for gitdir: pattern matching in includeIf.
-			// #nosec G204 -- tempDir is created by the test framework
-			err = exec.Command("git", "init", tempDir).Run()
-			framework.ExpectNoError(err)
-
-			gitConfigDir := ginkgo.GinkgoT().TempDir()
-
-			projectConfigPath := filepath.Join(gitConfigDir, "project.gitconfig")
-			err = os.WriteFile(projectConfigPath, []byte(`[user]
-	email = project@devpod-test.com
-	name = Project User
-`), 0o600)
-			framework.ExpectNoError(err)
-
-			globalConfigPath := filepath.Join(gitConfigDir, "global.gitconfig")
-			globalContent := fmt.Appendf(nil, `[user]
-	email = global@devpod-test.com
-	name = Global User
-[includeIf "gitdir:%s/"]
-	path = %s
-`, tempDir, projectConfigPath)
-			err = os.WriteFile(globalConfigPath, globalContent, 0o600)
-			framework.ExpectNoError(err)
-
-			ginkgo.GinkgoWriter.Printf(
-				"globalConfigPath=%s projectConfigPath=%s tempDir=%s\n",
-				globalConfigPath, projectConfigPath, tempDir,
-			)
-
-			ginkgo.GinkgoT().Setenv("GIT_CONFIG_GLOBAL", globalConfigPath)
-			ginkgo.GinkgoT().Setenv("GIT_CONFIG_NOSYSTEM", "1")
-
-			// Verify the includeIf resolves on the host before starting devpod.
-			// #nosec G204 -- tempDir is from framework.CopyToTempDir
-			hostEmail, hostErr := exec.Command("git", "-C", tempDir, "config", "user.email").Output()
-			ginkgo.GinkgoWriter.Printf(
-				"host git config user.email in tempDir: %q err=%v\n",
-				strings.TrimSpace(string(hostEmail)), hostErr,
-			)
-
-			err = f.DevPodUp(ctx, tempDir)
-			framework.ExpectNoError(err)
-
-			// Snapshot git config state immediately after devpod up (no services).
-			snapCmd := "echo 'USER='$(whoami)" +
-				"; echo 'HOME='$HOME" +
-				"; git config --list 2>&1 | grep -E 'user\\.' || echo '(no user config)'"
-			snapOut, snapErr, _ := f.ExecCommandCapture(ctx, []string{
-				"ssh", "--start-services=false", tempDir,
-				"--command", snapCmd,
-			})
-			ginkgo.GinkgoWriter.Printf("post-up snapshot stdout: %s\n", snapOut)
-			ginkgo.GinkgoWriter.Printf("post-up snapshot stderr: %s\n", snapErr)
-
-			// The credentials server configures git user asynchronously when
-			// devpod ssh starts its services goroutine. Retry until the email
-			// is set or the 30-second window expires. Print progress each
-			// iteration so CI logs show exactly when (or whether) it is set.
-			checkCmd := "for i in $(seq 1 30); do" +
-				" out=$(git config --global user.email 2>/dev/null);" +
-				" printf 'iter %d: email=%s\\n' \"$i\" \"$out\" >&2;" +
-				" [ -n \"$out\" ] && echo \"$out\" && exit 0;" +
-				" sleep 1;" +
-				" done;" +
-				" echo 'timeout: git config --list:' >&2;" +
-				" git config --list >&2 2>&1;" +
-				" exit 1"
-
-			stdout, stderr, err := f.ExecCommandCapture(ctx, []string{
-				"ssh",
-				"--start-services",
-				tempDir,
-				"--command", checkCmd,
-			})
-			ginkgo.GinkgoWriter.Printf("stdout: %s\n", stdout)
-			ginkgo.GinkgoWriter.Printf("stderr: %s\n", stderr)
-			framework.ExpectNoError(err)
-			gomega.Expect(strings.TrimSpace(stdout)).To(
-				gomega.Equal("project@devpod-test.com"),
-				"container should receive the includeIf-resolved email, not the global default",
 			)
 		},
 	)

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -438,15 +438,60 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			err = os.WriteFile(globalConfigPath, globalContent, 0o600)
 			framework.ExpectNoError(err)
 
+			ginkgo.GinkgoWriter.Printf(
+				"globalConfigPath=%s projectConfigPath=%s tempDir=%s\n",
+				globalConfigPath, projectConfigPath, tempDir,
+			)
+
 			ginkgo.GinkgoT().Setenv("GIT_CONFIG_GLOBAL", globalConfigPath)
 			ginkgo.GinkgoT().Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+			// Verify the includeIf resolves on the host before starting devpod.
+			// #nosec G204 -- tempDir is from framework.CopyToTempDir
+			hostEmail, hostErr := exec.Command("git", "-C", tempDir, "config", "user.email").Output()
+			ginkgo.GinkgoWriter.Printf(
+				"host git config user.email in tempDir: %q err=%v\n",
+				strings.TrimSpace(string(hostEmail)), hostErr,
+			)
 
 			err = f.DevPodUp(ctx, tempDir)
 			framework.ExpectNoError(err)
 
-			out, err := f.DevPodSSH(ctx, tempDir, "git config user.email")
+			// Snapshot git config state immediately after devpod up (no services).
+			snapCmd := "echo 'USER='$(whoami)" +
+				"; echo 'HOME='$HOME" +
+				"; git config --list 2>&1 | grep -E 'user\\.' || echo '(no user config)'"
+			snapOut, snapErr, _ := f.ExecCommandCapture(ctx, []string{
+				"ssh", "--start-services=false", tempDir,
+				"--command", snapCmd,
+			})
+			ginkgo.GinkgoWriter.Printf("post-up snapshot stdout: %s\n", snapOut)
+			ginkgo.GinkgoWriter.Printf("post-up snapshot stderr: %s\n", snapErr)
+
+			// The credentials server configures git user asynchronously when
+			// devpod ssh starts its services goroutine. Retry until the email
+			// is set or the 30-second window expires. Print progress each
+			// iteration so CI logs show exactly when (or whether) it is set.
+			checkCmd := "for i in $(seq 1 30); do" +
+				" out=$(git config --global user.email 2>/dev/null);" +
+				" printf 'iter %d: email=%s\\n' \"$i\" \"$out\" >&2;" +
+				" [ -n \"$out\" ] && echo \"$out\" && exit 0;" +
+				" sleep 1;" +
+				" done;" +
+				" echo 'timeout: git config --list:' >&2;" +
+				" git config --list >&2 2>&1;" +
+				" exit 1"
+
+			stdout, stderr, err := f.ExecCommandCapture(ctx, []string{
+				"ssh",
+				"--start-services",
+				tempDir,
+				"--command", checkCmd,
+			})
+			ginkgo.GinkgoWriter.Printf("stdout: %s\n", stdout)
+			ginkgo.GinkgoWriter.Printf("stderr: %s\n", stderr)
 			framework.ExpectNoError(err)
-			gomega.Expect(strings.TrimSpace(out)).To(
+			gomega.Expect(strings.TrimSpace(stdout)).To(
 				gomega.Equal("project@devpod-test.com"),
 				"container should receive the includeIf-resolved email, not the global default",
 			)

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"net"
 	"os"
@@ -392,6 +393,62 @@ var _ = ginkgo.Describe("devpod ssh test suite", ginkgo.Label("ssh"), ginkgo.Ord
 			gomega.Expect(combined).NotTo(
 				gomega.ContainSubstring("invalid character"),
 				"error should not contain JSON parse errors — error messages must be human-readable",
+			)
+		},
+	)
+
+	ginkgo.It(
+		"should forward git includeIf-resolved user identity into the devcontainer",
+		ginkgo.SpecTimeout(7*time.Minute),
+		func(ctx ginkgo.SpecContext) {
+			tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
+			framework.ExpectNoError(err)
+
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+			_ = f.DevPodProviderAdd(ctx, "docker")
+			err = f.DevPodProviderUse(ctx, "docker")
+			framework.ExpectNoError(err)
+
+			ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+				_ = f.DevPodWorkspaceDelete(cleanupCtx, tempDir)
+				framework.CleanupTempDir(initialDir, tempDir)
+			})
+
+			// git init is required for gitdir: pattern matching in includeIf.
+			// #nosec G204 -- tempDir is created by the test framework
+			err = exec.Command("git", "init", tempDir).Run()
+			framework.ExpectNoError(err)
+
+			gitConfigDir := ginkgo.GinkgoT().TempDir()
+
+			projectConfigPath := filepath.Join(gitConfigDir, "project.gitconfig")
+			err = os.WriteFile(projectConfigPath, []byte(`[user]
+	email = project@devpod-test.com
+	name = Project User
+`), 0o600)
+			framework.ExpectNoError(err)
+
+			globalConfigPath := filepath.Join(gitConfigDir, "global.gitconfig")
+			globalContent := fmt.Appendf(nil, `[user]
+	email = global@devpod-test.com
+	name = Global User
+[includeIf "gitdir:%s/"]
+	path = %s
+`, tempDir, projectConfigPath)
+			err = os.WriteFile(globalConfigPath, globalContent, 0o600)
+			framework.ExpectNoError(err)
+
+			ginkgo.GinkgoT().Setenv("GIT_CONFIG_GLOBAL", globalConfigPath)
+			ginkgo.GinkgoT().Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+			err = f.DevPodUp(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			out, err := f.DevPodSSH(ctx, tempDir, "git config user.email")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(out)).To(
+				gomega.Equal("project@devpod-test.com"),
+				"container should receive the includeIf-resolved email, not the global default",
 			)
 		},
 	)

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -224,7 +224,11 @@ func (t *tunnelServer) DockerCredentials(
 }
 
 func (t *tunnelServer) GitUser(ctx context.Context, empty *tunnel.Empty) (*tunnel.Message, error) {
-	gitUser, err := gitcredentials.GetUser("")
+	workingDir := ""
+	if t.workspace != nil {
+		workingDir = t.workspace.Source.LocalFolder
+	}
+	gitUser, err := gitcredentials.GetUser("", workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -160,6 +160,7 @@ func setupOptionalFeatures(ctx context.Context, cfg *ContainerSetupConfig) {
 	if cfg.PlatformOptions != nil {
 		if err := setupPlatformGitCredentials(
 			config.GetRemoteUser(cfg.SetupInfo),
+			cfg.SetupInfo.SubstitutionContext.LocalWorkspaceFolder,
 			cfg.PlatformOptions,
 			cfg.Log,
 		); err != nil {
@@ -453,6 +454,7 @@ func markerFileExists(markerName string, markerContent string) (bool, error) {
 
 func setupPlatformGitCredentials(
 	userName string,
+	workingDir string,
 	platformOptions *devsy.PlatformOptions,
 	log log.Logger,
 ) error {
@@ -464,7 +466,7 @@ func setupPlatformGitCredentials(
 	// setup platform git user
 	if platformOptions.UserCredentials.GitUser != "" &&
 		platformOptions.UserCredentials.GitEmail != "" {
-		gitUser, err := gitcredentials.GetUser(userName)
+		gitUser, err := gitcredentials.GetUser(userName, workingDir)
 		if err == nil && gitUser.Name == "" && gitUser.Email == "" {
 			log.Info("Setup workspace git user and email")
 			err := gitcredentials.SetUser(userName, &gitcredentials.GitUser{

--- a/pkg/gitcredentials/gitcredentials.go
+++ b/pkg/gitcredentials/gitcredentials.go
@@ -185,7 +185,7 @@ func SetUser(userName string, user *GitUser) error {
 	return nil
 }
 
-func GetUser(userName string) (*GitUser, error) {
+func GetUser(userName string, workingDir string) (*GitUser, error) {
 	gitUser := &GitUser{}
 
 	scopeArgs := []string{"config"}
@@ -195,15 +195,25 @@ func GetUser(userName string) (*GitUser, error) {
 			return gitUser, fmt.Errorf("get git global dir for %s: %w", userName, err)
 		}
 		scopeArgs = append(scopeArgs, "--file", p)
-	} else {
+	} else if workingDir == "" {
 		scopeArgs = append(scopeArgs, "--global")
 	}
 
+	// #nosec G204 -- fixed argument
+	nameCmd := exec.Command("git", append(scopeArgs, "user.name")...)
+	// #nosec G204 -- fixed argument
+	emailCmd := exec.Command("git", append(scopeArgs, "user.email")...)
+
+	if workingDir != "" {
+		nameCmd.Dir = workingDir
+		emailCmd.Dir = workingDir
+	}
+
 	// we ignore the error here, because if email is empty we don't care
-	name, _ := exec.Command("git", append(scopeArgs[:], "user.name")...).Output()
+	name, _ := nameCmd.Output()
 	gitUser.Name = strings.TrimSpace(string(name))
 
-	email, _ := exec.Command("git", append(scopeArgs[:], "user.email")...).Output()
+	email, _ := emailCmd.Output()
 	gitUser.Email = strings.TrimSpace(string(email))
 
 	return gitUser, nil

--- a/pkg/gitcredentials/gitcredentials_test.go
+++ b/pkg/gitcredentials/gitcredentials_test.go
@@ -1,0 +1,95 @@
+package gitcredentials
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUser_WorkingDirResolvesIncludeIf(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	projectDir := t.TempDir()
+	// #nosec G204 -- projectDir is a temp directory created by the test
+	cmd := exec.Command("git", "init", projectDir)
+	require.NoError(t, cmd.Run())
+
+	projectConfigPath := filepath.Join(tmpHome, "project.gitconfig")
+	require.NoError(t, os.WriteFile(projectConfigPath, []byte(`[user]
+	name = Project User
+	email = project@example.com
+`), 0o600))
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, fmt.Appendf(nil, `[user]
+	name = Global User
+	email = global@example.com
+[includeIf "gitdir:%s/"]
+	path = %s
+`, projectDir, projectConfigPath), 0o600))
+
+	user, err := GetUser("", projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, "Project User", user.Name)
+	assert.Equal(t, "project@example.com", user.Email)
+}
+
+func TestGetUser_EmptyWorkingDirUsesGlobal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, []byte(`[user]
+	name = Global User
+	email = global@example.com
+`), 0o600))
+
+	user, err := GetUser("", "")
+	require.NoError(t, err)
+	assert.Equal(t, "Global User", user.Name)
+	assert.Equal(t, "global@example.com", user.Email)
+}
+
+func TestGetUser_WorkingDirWithNoMatchingIncludeIfUsesGlobal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	otherDir := t.TempDir()
+
+	projectConfigPath := filepath.Join(tmpHome, "project.gitconfig")
+	require.NoError(t, os.WriteFile(projectConfigPath, []byte(`[user]
+	name = Project User
+	email = project@example.com
+`), 0o600))
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, fmt.Appendf(nil, `[user]
+	name = Global User
+	email = global@example.com
+[includeIf "gitdir:%s/"]
+	path = %s
+`, otherDir, projectConfigPath), 0o600))
+
+	// workingDir does not match the includeIf pattern — global values should come through
+	projectDir := t.TempDir()
+	// #nosec G204 -- projectDir is a temp directory created by the test
+	cmd := exec.Command("git", "init", projectDir)
+	require.NoError(t, cmd.Run())
+
+	user, err := GetUser("", projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, "Global User", user.Name)
+	assert.Equal(t, "global@example.com", user.Email)
+}

--- a/pkg/gitsshsigning/utils.go
+++ b/pkg/gitsshsigning/utils.go
@@ -13,13 +13,15 @@ const (
 
 // ExtractGitConfiguration is used for extracting values from users local .gitconfig
 // that are needed to setup devpod-ssh-signature helper inside the workspace.
-func ExtractGitConfiguration() (string, string, error) {
-	format, err := readGitConfigValue(GPGFormatConfigKey)
+// When workingDir is non-empty the git commands run there so that includeIf "gitdir:..."
+// directives are evaluated relative to the project root.
+func ExtractGitConfiguration(workingDir string) (string, string, error) {
+	format, err := readGitConfigValue(GPGFormatConfigKey, workingDir)
 	if err != nil {
 		return "", "", err
 	}
 
-	signingKey, err := readGitConfigValue(UsersSigningKeyConfigKey)
+	signingKey, err := readGitConfigValue(UsersSigningKeyConfigKey, workingDir)
 	if err != nil {
 		return "", "", err
 	}
@@ -27,8 +29,11 @@ func ExtractGitConfiguration() (string, string, error) {
 	return format, signingKey, nil
 }
 
-func readGitConfigValue(key string) (string, error) {
+func readGitConfigValue(key string, workingDir string) (string, error) {
 	cmd := exec.Command("git", "config", "--get", key)
+	if workingDir != "" {
+		cmd.Dir = workingDir
+	}
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/pkg/gitsshsigning/utils_test.go
+++ b/pkg/gitsshsigning/utils_test.go
@@ -1,0 +1,56 @@
+package gitsshsigning
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractGitConfiguration_WorkingDirResolvesIncludeIf(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	projectDir := t.TempDir()
+	// #nosec G204 -- projectDir is a temp directory created by the test
+	cmd := exec.Command("git", "init", projectDir)
+	require.NoError(t, cmd.Run())
+
+	projectConfigPath := filepath.Join(tmpHome, "project.gitconfig")
+	require.NoError(t, os.WriteFile(projectConfigPath, []byte(`[gpg]
+	format = ssh
+[user]
+	signingkey = /path/to/signing.pub
+`), 0o600))
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, fmt.Appendf(nil, `[includeIf "gitdir:%s/"]
+	path = %s
+`, projectDir, projectConfigPath), 0o600))
+
+	format, signingKey, err := ExtractGitConfiguration(projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, GPGFormatSSH, format)
+	assert.Equal(t, "/path/to/signing.pub", signingKey)
+}
+
+func TestExtractGitConfiguration_EmptyWorkingDir_NoSigningConfig(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, []byte(`[user]
+	email = global@example.com
+`), 0o600))
+
+	_, _, err := ExtractGitConfiguration("")
+	assert.Error(t, err)
+}

--- a/pkg/tunnel/services.go
+++ b/pkg/tunnel/services.go
@@ -108,10 +108,17 @@ func runTunnelServer(ctx context.Context, cancel context.CancelFunc, p tunnelSer
 // When explicitKey is set (from --git-ssh-signing-key flag), it takes
 // precedence over the host's .gitconfig. This ensures signing works
 // even when user.signingkey is not in the host git configuration.
-func addGitSSHSigningKey(command string, explicitKey string, log log.Logger) string {
+// workingDir, when non-empty, is the project root used so that
+// includeIf "gitdir:..." directives are evaluated correctly.
+func addGitSSHSigningKey(
+	command string,
+	explicitKey string,
+	workingDir string,
+	log log.Logger,
+) string {
 	userSigningKey := explicitKey
 	if userSigningKey == "" {
-		format, extracted, err := gitsshsigning.ExtractGitConfiguration()
+		format, extracted, err := gitsshsigning.ExtractGitConfiguration(workingDir)
 		if err != nil {
 			log.Debugf("failed to extract git configuration: %v", err)
 			return command
@@ -137,7 +144,11 @@ func buildCredentialsCommand(opts RunServicesOptions) string {
 		command += " --configure-git-helper"
 	}
 	if opts.ConfigureGitSSHSignatureHelper {
-		command = addGitSSHSigningKey(command, opts.GitSSHSigningKey, opts.Log)
+		workingDir := ""
+		if opts.Workspace != nil {
+			workingDir = opts.Workspace.Source.LocalFolder
+		}
+		command = addGitSSHSigningKey(command, opts.GitSSHSigningKey, workingDir, opts.Log)
 	}
 	if opts.ConfigureDockerCredentials {
 		command += " --configure-docker-helper"

--- a/pkg/tunnel/services_test.go
+++ b/pkg/tunnel/services_test.go
@@ -12,7 +12,7 @@ const testBaseCommand = "devpod agent container credentials-server --user root"
 
 func TestAddGitSSHSigningKey_ExplicitKey(t *testing.T) {
 	command := testBaseCommand
-	result := addGitSSHSigningKey(command, "/path/to/key.pub", log.Discard)
+	result := addGitSSHSigningKey(command, "/path/to/key.pub", "", log.Discard)
 
 	encoded := base64.StdEncoding.EncodeToString([]byte("/path/to/key.pub"))
 	assert.Equal(t, command+" --git-user-signing-key "+encoded, result)
@@ -23,7 +23,7 @@ func TestAddGitSSHSigningKey_ExplicitKeyTakesPrecedence(t *testing.T) {
 	// of what ExtractGitConfiguration might return from host .gitconfig.
 	command := testBaseCommand
 	explicitKey := "/explicit/key.pub"
-	result := addGitSSHSigningKey(command, explicitKey, log.Discard)
+	result := addGitSSHSigningKey(command, explicitKey, "", log.Discard)
 
 	encoded := base64.StdEncoding.EncodeToString([]byte(explicitKey))
 	assert.Equal(t, command+" --git-user-signing-key "+encoded, result)
@@ -36,7 +36,7 @@ func TestAddGitSSHSigningKey_EmptyExplicitKey_FallsBackToHostConfig(t *testing.T
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("XDG_CONFIG_HOME", tmpHome)
 
-	result := addGitSSHSigningKey(command, "", log.Discard)
+	result := addGitSSHSigningKey(command, "", "", log.Discard)
 
 	assert.Equal(t, command, result)
 	assert.NotContains(t, result, "--git-user-signing-key")


### PR DESCRIPTION
closes #750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git identity and SSH-signing now respect project-local git configuration (includeIf gitdir), resolving config relative to the repository so per-project name/email and signing keys are honored inside workspaces and forwarded into containers.

* **Tests**
  * Added unit and end-to-end tests validating project-scoped git user/email and SSH signing key resolution are correctly propagated into containers and SSH sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skevetter/devpod/pull/755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->