### PR TITLE
ci: replace chocolatey kind and podman setup

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -325,6 +325,41 @@ jobs:
           UUID=$(python -c "import uuid; print(uuid.uuid4().hex)")
           echo "result=$UUID" >> "$GITHUB_OUTPUT"
 
+      - name: install and start podman (Windows)
+        if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        shell: pwsh
+        run: |
+          $msiUrl = "https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi"
+          $msiPath = "$env:RUNNER_TEMP\podman.msi"
+          Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath
+
+          $expectedHash = "eda54f26f9695d198d9a679fa45ae24ba35b78444f432b5fe0c122c5a3624c57"
+          $actualHash = (Get-FileHash -Path $msiPath -Algorithm SHA256).Hash.ToLower()
+          if ($actualHash -ne $expectedHash) {
+            throw "SHA256 mismatch for podman MSI! Expected: $expectedHash, Got: $actualHash"
+          }
+          Write-Host "Podman MSI checksum verified: $actualHash"
+
+          $installDir = "C:\Program Files\RedHat\Podman"
+          $logFile = "$env:RUNNER_TEMP\podman-install.log"
+          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/i `"$msiPath`" /qn /norestart /l*v `"$logFile`" INSTALLDIR=`"$installDir`""
+          Write-Host "MSI exit code: $($proc.ExitCode)"
+
+          if (!(Test-Path "$installDir\podman.exe")) {
+            Write-Host "--- MSI install log (last 50 lines) ---"
+            Get-Content $logFile -Tail 50
+            Write-Host "--- Searching for podman.exe ---"
+            Get-ChildItem "C:\" -Filter "podman.exe" -Recurse -Depth 4 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.FullName }
+            throw "podman.exe not found at $installDir"
+          }
+
+          echo "$installDir" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+          wsl --set-default-version 2
+          & "$installDir\podman.exe" machine init
+          & "$installDir\podman.exe" machine set --rootful
+          & "$installDir\podman.exe" machine start
+
       - name: setup kind (Windows)
         if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
         shell: bash
@@ -332,14 +367,20 @@ jobs:
           KIND_EXPERIMENTAL_PROVIDER: podman
           DOCKER_HOST: npipe:////./pipe/podman-machine-default
         run: |
-          wsl --set-default-version 2
-          choco install podman-cli kind -y
+          curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
+          expected="6f724188289cc79395f45afae0f2b85e0d220c2b84c6ed2f5047d9d0c9a67028"
+          actual=$(sha256sum "$RUNNER_TEMP/kind.exe" | awk '{print $1}' | sed 's/^[^a-f0-9]*//')
+          if [ "$actual" != "$expected" ]; then
+            echo "SHA256 mismatch for kind.exe! Expected: $expected, Got: $actual"
+            exit 1
+          fi
+          echo "kind.exe checksum verified: $actual"
 
-          podman machine init
-          podman machine set --rootful
-          podman machine start
+          export PATH="$RUNNER_TEMP:$PATH"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
-          kind create cluster --name "${{ steps.uuid.outputs.result }}" --image kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+          CLUSTER_NAME=$(python -c "import uuid; print(uuid.uuid4().hex)")
+          kind create cluster --name "$CLUSTER_NAME" --image kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 
       # NOTE: skevetter/setup-kind does not work on Windows runners
       - name: setup kind

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+const httpPort = "8080:80"
+
 func writeGitConfig(t *testing.T, content string) {
 	t.Helper()
 	home := t.TempDir()
@@ -116,7 +118,7 @@ func runPortForwardsForTest(
 }
 
 func TestRunPortForwards_CleanExit(t *testing.T) {
-	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{"8080:80"}, func(
+	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{httpPort}, func(
 		context.Context,
 		*ssh.Client,
 		string,
@@ -134,7 +136,7 @@ func TestRunPortForwards_CleanExit(t *testing.T) {
 }
 
 func TestRunPortForwards_EOFExit(t *testing.T) {
-	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{"8080:80"}, func(
+	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{httpPort}, func(
 		context.Context,
 		*ssh.Client,
 		string,
@@ -152,7 +154,7 @@ func TestRunPortForwards_EOFExit(t *testing.T) {
 }
 
 func TestRunPortForwards_ForwardError(t *testing.T) {
-	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{"8080:80"}, func(
+	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{httpPort}, func(
 		context.Context,
 		*ssh.Client,
 		string,
@@ -174,7 +176,7 @@ func TestRunPortForwards_UsesConfiguredTimeout(t *testing.T) {
 	cmd := &SSHCmd{ForwardPortsTimeout: "90s"}
 	var gotTimeout time.Duration
 
-	calls, err := runPortForwardsForTest(t, cmd, []string{"8080:80"}, func(
+	calls, err := runPortForwardsForTest(t, cmd, []string{httpPort}, func(
 		_ context.Context,
 		_ *ssh.Client,
 		_ string,
@@ -194,7 +196,7 @@ func TestRunPortForwards_UsesConfiguredTimeout(t *testing.T) {
 }
 
 func TestRunPortForwards_ParseErrorStopsBeforeLaunch(t *testing.T) {
-	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{"8080:80", ""}, func(
+	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{httpPort, ""}, func(
 		context.Context,
 		*ssh.Client,
 		string,
@@ -216,7 +218,7 @@ func TestRunPortForwards_MultipleMappingsReturnError(t *testing.T) {
 	var started atomic.Int32
 	ready := make(chan struct{})
 
-	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{"8080:80", "8081:81"}, func(
+	calls, err := runPortForwardsForTest(t, &SSHCmd{}, []string{httpPort, "8081:81"}, func(
 		_ context.Context,
 		_ *ssh.Client,
 		_ string,

--- a/pkg/port/parse.go
+++ b/pkg/port/parse.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const unix = "unix"
+
 type Address struct {
 	Protocol string
 	Address  string
@@ -102,7 +104,7 @@ func toUnixAddress(ip, port string, opts addressOptions) (Address, error) {
 	}
 
 	return Address{
-		Protocol: "unix",
+		Protocol: unix,
 		Address:  port,
 	}, nil
 }

--- a/pkg/port/parse_test.go
+++ b/pkg/port/parse_test.go
@@ -59,8 +59,8 @@ func TestParsePortSpec_DelegatesUnixSocketMappings(t *testing.T) {
 	mapping, err := ParsePortSpec("/tmp/local.sock:/tmp/remote.sock")
 	require.NoError(t, err)
 	assert.Equal(t, Mapping{
-		Host:      Address{Protocol: "unix", Address: "/tmp/local.sock"},
-		Container: Address{Protocol: "unix", Address: "/tmp/remote.sock"},
+		Host:      Address{Protocol: unix, Address: "/tmp/local.sock"},
+		Container: Address{Protocol: unix, Address: "/tmp/remote.sock"},
 	}, mapping)
 }
 


### PR DESCRIPTION
install podman and kind directly due to issues with chocolatey installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows integration test setup with improved installation verification and initialization procedures
  * Refactored internal constants and test assertions for better code maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skevetter/devpod/pull/757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->