### PR TITLE
Migrate kubectl exec to WebSockets from SPDY

### DIFF
--- a/pkg/driver/kubernetes/client.go
+++ b/pkg/driver/kubernetes/client.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -115,7 +116,16 @@ func (c *Client) Exec(ctx context.Context, options *ExecStreamOptions) error {
 			Stderr:    options.Stderr != nil,
 		}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(c.config, "POST", execRequest.URL())
+	// Use WebSocket executor which is the default as of Kubernetes 1.31. Fall back to SPDY for older clusters.
+	websocketExec, err := remotecommand.NewWebSocketExecutor(c.config, "GET", execRequest.URL().String())
+	if err != nil {
+		return err
+	}
+	spdyExec, err := remotecommand.NewSPDYExecutor(c.config, "POST", execRequest.URL())
+	if err != nil {
+		return err
+	}
+	exec, err := remotecommand.NewFallbackExecutor(websocketExec, spdyExec, httpstream.IsUpgradeFailure)
 	if err != nil {
 		return err
 	}

--- a/pkg/driver/kubernetes/client.go
+++ b/pkg/driver/kubernetes/client.go
@@ -125,7 +125,9 @@ func (c *Client) Exec(ctx context.Context, options *ExecStreamOptions) error {
 	if err != nil {
 		return err
 	}
-	exec, err := remotecommand.NewFallbackExecutor(websocketExec, spdyExec, httpstream.IsUpgradeFailure)
+	exec, err := remotecommand.NewFallbackExecutor(websocketExec, spdyExec, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
( clone of PR https://github.com/loft-sh/devpod/pull/1980 )

I've added websocket support since I want to setup a [capsule kube api proxy](https://github.com/projectcapsule/capsule-proxy)  which was dropping connections due to lack of SPDY support. 

Per [KEP-4006](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/4006-transition-spdy-to-websockets), I prioritize trying WebSockets first given Websockets have been the default for 4 versions now and will be the standard going forward. I used `NewFallbackExecutor` as suggested in the KEP to avoid breaking existing use cases.

This follows the implementation used by kubectl: https://github.com/kubernetes/kubectl/blob/8144b746a47f142759a073a46f581de92b1886aa/pkg/cmd/exec/exec.go#L146-L166

I've built this locally and have been using it successfully for myself and a few others. Disclosure: this fix was found with the assistance of claude/copilot. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote command reliability for Kubernetes by preferring a WebSocket-based connection method and retaining the legacy transport only as a fallback when the WebSocket upgrade cannot be established. This reduces unnecessary fallbacks and yields more stable, compatible remote command sessions across varied cluster, proxy, and network environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skevetter/devpod/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->