### PR TITLE
fix: flush tunnel logger before agent shutdown

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -104,6 +104,14 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 		return err
 	}
 
+	// The tunnel logger forwards messages over the tunnel asynchronously, so
+	// flush before returning to make sure the final log lines (e.g. the last
+	// stderr output of a failing lifecycle hook) reach the client before the
+	// connection is torn down. ctx is still alive while this defer runs.
+	if f, ok := logger.(interface{ Flush() }); ok {
+		defer f.Flush()
+	}
+
 	workspaceInfo, setupInfo, err := cmd.parseWorkspaceAndSetupInfo(logger)
 	if err != nil {
 		return err

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -108,7 +108,7 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 	// flush before returning to make sure the final log lines (e.g. the last
 	// stderr output of a failing lifecycle hook) reach the client before the
 	// connection is torn down. ctx is still alive while this defer runs.
-	if f, ok := logger.(interface{ Flush() }); ok {
+	if f, ok := logger.(tunnelserver.Flusher); ok {
 		defer f.Flush()
 	}
 

--- a/e2e/tests/up/handles_errors.go
+++ b/e2e/tests/up/handles_errors.go
@@ -81,11 +81,14 @@ var _ = ginkgo.Describe(
 					_ = f.DevPodWorkspaceDelete(cleanupCtx, tempDir, "--force")
 				})
 
-				// The postCreateCommand prints a marker to stderr and exits
-				// non-zero. The agent forwards lifecycle hook output over the
-				// tunnel asynchronously, so on failure it must flush the final
-				// queued line before tearing down. Regression guard for the
-				// dropped-last-line bug.
+				// The postCreateCommand prints a burst of stderr lines ending
+				// with a marker, then exits non-zero. The agent forwards
+				// lifecycle hook output over the tunnel asynchronously; the
+				// burst keeps the sender busy so the final marker is still
+				// queued when the hook fails, and the agent must flush it
+				// before tearing down. Without the flush the marker is dropped
+				// (a lone final line drains in time and would not reproduce the
+				// bug). Regression guard for the dropped-last-line bug.
 				stdout, stderr, err := f.DevPodUpStreams(ctx, tempDir, "--log-output=json")
 				framework.ExpectError(err, "expected lifecycle hook failure")
 				framework.ExpectNoError(

--- a/e2e/tests/up/handles_errors.go
+++ b/e2e/tests/up/handles_errors.go
@@ -81,14 +81,16 @@ var _ = ginkgo.Describe(
 					_ = f.DevPodWorkspaceDelete(cleanupCtx, tempDir, "--force")
 				})
 
-				// The postCreateCommand prints a burst of stderr lines ending
-				// with a marker, then exits non-zero. The agent forwards
-				// lifecycle hook output over the tunnel asynchronously; the
-				// burst keeps the sender busy so the final marker is still
-				// queued when the hook fails, and the agent must flush it
-				// before tearing down. Without the flush the marker is dropped
-				// (a lone final line drains in time and would not reproduce the
-				// bug). Regression guard for the dropped-last-line bug.
+				// The postCreateCommand runs a script that prints a burst of
+				// stderr lines ending with a marker, then exits non-zero. The
+				// agent forwards lifecycle hook output over the tunnel
+				// asynchronously; the burst keeps the sender busy so the final
+				// marker is still queued when the hook fails, and the agent
+				// must flush it before tearing down. Without the flush the
+				// marker is dropped. The marker lives in the script (not the
+				// inline command) so it cannot leak into devpod's "failed to
+				// run <command>" error and cause a false positive. Regression
+				// guard for the dropped-last-line bug.
 				stdout, stderr, err := f.DevPodUpStreams(ctx, tempDir, "--log-output=json")
 				framework.ExpectError(err, "expected lifecycle hook failure")
 				framework.ExpectNoError(

--- a/e2e/tests/up/handles_errors.go
+++ b/e2e/tests/up/handles_errors.go
@@ -64,6 +64,41 @@ var _ = ginkgo.Describe(
 		)
 
 		ginkgo.It(
+			"forwards the final lifecycle hook log line before the agent exits",
+			func(ctx context.Context) {
+				f, err := setupDockerProvider(initialDir+"/bin", "docker")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevPodProviderDelete(cleanupCtx, "docker")
+				})
+
+				tempDir, err := framework.CopyToTempDir(
+					"tests/up/testdata/docker-lifecycle-stderr",
+				)
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevPodWorkspaceDelete(cleanupCtx, tempDir, "--force")
+				})
+
+				// The postCreateCommand prints a marker to stderr and exits
+				// non-zero. The agent forwards lifecycle hook output over the
+				// tunnel asynchronously, so on failure it must flush the final
+				// queued line before tearing down. Regression guard for the
+				// dropped-last-line bug.
+				stdout, stderr, err := f.DevPodUpStreams(ctx, tempDir, "--log-output=json")
+				framework.ExpectError(err, "expected lifecycle hook failure")
+				framework.ExpectNoError(
+					findMessage(
+						strings.NewReader(stdout+stderr),
+						"DEVPOD_LIFECYCLE_FLUSH_MARKER",
+					),
+				)
+			},
+			ginkgo.SpecTimeout(framework.GetTimeout()),
+		)
+
+		ginkgo.It(
 			"ensure workspace cleanup when failing to create a workspace",
 			func(ctx context.Context) {
 				f, err := setupDockerProvider(initialDir+"/bin", "docker")

--- a/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer.json
@@ -1,5 +1,5 @@
 {
   "name": "lifecycle-stderr",
   "image": "mcr.microsoft.com/devcontainers/go:1",
-  "postCreateCommand": "echo DEVPOD_LIFECYCLE_FLUSH_MARKER >&2; exit 1"
+  "postCreateCommand": "i=0; while [ $i -lt 300 ]; do echo \"filler line $i\" >&2; i=$((i+1)); done; echo DEVPOD_LIFECYCLE_FLUSH_MARKER >&2; exit 1"
 }

--- a/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "lifecycle-stderr",
+  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "postCreateCommand": "echo DEVPOD_LIFECYCLE_FLUSH_MARKER >&2; exit 1"
+}

--- a/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer.json
@@ -1,5 +1,0 @@
-{
-  "name": "lifecycle-stderr",
-  "image": "mcr.microsoft.com/devcontainers/go:1",
-  "postCreateCommand": "i=0; while [ $i -lt 300 ]; do echo \"filler line $i\" >&2; i=$((i+1)); done; echo DEVPOD_LIFECYCLE_FLUSH_MARKER >&2; exit 1"
-}

--- a/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer/devcontainer.json
+++ b/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "lifecycle-stderr",
+  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "postCreateCommand": "sh .devcontainer/postCreateCommand.sh"
+}

--- a/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer/postCreateCommand.sh
+++ b/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer/postCreateCommand.sh
@@ -14,8 +14,8 @@
 # produce a false positive.
 i=0
 while [ "$i" -lt 300 ]; do
-	echo "filler line $i" >&2
-	i=$((i + 1))
+    echo "filler line $i" >&2
+    i=$((i + 1))
 done
 echo DEVPOD_LIFECYCLE_FLUSH_MARKER >&2
 exit 1

--- a/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer/postCreateCommand.sh
+++ b/e2e/tests/up/testdata/docker-lifecycle-stderr/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Regression fixture for the dropped-last-line bug (see the e2e spec
+# "forwards the final lifecycle hook log line before the agent exits").
+#
+# Emit a burst of stderr lines ending with a marker, then fail. The agent
+# forwards lifecycle hook output over the tunnel asynchronously; the burst
+# keeps the sender busy so the marker is still queued when the hook exits
+# non-zero. Without the flush-on-shutdown fix the agent tears down before the
+# marker is sent and it is dropped (the observed drain window is only ~11
+# lines, so the 300-line burst leaves a wide margin).
+#
+# The marker lives in this script rather than the inline postCreateCommand so
+# it cannot leak into devpod's "failed to run <command>" error message and
+# produce a false positive.
+i=0
+while [ "$i" -lt 300 ]; do
+	echo "filler line $i" >&2
+	i=$((i + 1))
+done
+echo DEVPOD_LIFECYCLE_FLUSH_MARKER >&2
+exit 1

--- a/pkg/agent/tunnelserver/logger.go
+++ b/pkg/agent/tunnelserver/logger.go
@@ -35,6 +35,15 @@ func NewTunnelLogger(ctx context.Context, client tunnel.TunnelClient, debug bool
 	return logger
 }
 
+// Flusher is implemented by loggers that buffer output and can block until
+// everything queued so far has been delivered. NewTunnelLogger returns a value
+// satisfying this interface.
+type Flusher interface {
+	Flush()
+}
+
+var _ Flusher = (*tunnelLogger)(nil)
+
 // logEntry is what flows through the logger channel. It is either a log
 // message to forward over the tunnel, or a flush request whose ack channel is
 // closed once all preceding messages have been sent.

--- a/pkg/agent/tunnelserver/logger.go
+++ b/pkg/agent/tunnelserver/logger.go
@@ -28,6 +28,7 @@ func NewTunnelLogger(ctx context.Context, client tunnel.TunnelClient, debug bool
 		client:  client,
 		level:   level,
 		logChan: make(chan logEntry, 1000), // Buffer size of 1000 messages
+		done:    make(chan struct{}),
 	}
 
 	go logger.worker()
@@ -57,10 +58,12 @@ type tunnelLogger struct {
 	level   logrus.Level
 	client  tunnel.TunnelClient
 	logChan chan logEntry
+	done    chan struct{} // closed when worker() exits
 	fields  logrus.Fields
 }
 
 func (s *tunnelLogger) worker() {
+	defer close(s.done)
 	for {
 		select {
 		case entry := <-s.logChan:
@@ -81,19 +84,21 @@ func (s *tunnelLogger) worker() {
 }
 
 // Flush blocks until all messages queued before the call have been forwarded
-// over the tunnel. It must be called before the process exits (and before
-// s.ctx is cancelled) to guarantee the final log lines are delivered.
+// over the tunnel, or until the worker has stopped. It gates on worker
+// completion rather than s.ctx so it stays a real barrier even when s.ctx is
+// already cancelled (e.g. the deferred flush on the shutdown path, or
+// Fatal/Fatalf).
 func (s *tunnelLogger) Flush() {
 	ack := make(chan struct{})
 	select {
 	case s.logChan <- logEntry{flush: ack}:
-	case <-s.ctx.Done():
+	case <-s.done:
 		return
 	}
 
 	select {
 	case <-ack:
-	case <-s.ctx.Done():
+	case <-s.done:
 	}
 }
 
@@ -316,6 +321,7 @@ func (s *tunnelLogger) WithFields(fields logrus.Fields) log.Logger {
 		client:  s.client,
 		level:   s.level,
 		logChan: s.logChan,
+		done:    s.done,
 		fields:  newFields,
 	}
 }

--- a/pkg/agent/tunnelserver/logger.go
+++ b/pkg/agent/tunnelserver/logger.go
@@ -71,22 +71,6 @@ func (s *tunnelLogger) worker() {
 	}
 }
 
-// handle forwards a single message over the tunnel, or acknowledges a flush
-// request. Sends use a context detached from s.ctx's cancellation so that
-// queued messages can still be delivered during shutdown as long as the
-// underlying connection is alive.
-func (s *tunnelLogger) handle(entry logEntry) {
-	if entry.flush != nil {
-		close(entry.flush)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), 5*time.Second)
-	_, _ = s.client.Log(ctx, entry.msg)
-	// ignore error since we can't use the logger itself
-	cancel()
-}
-
 // Flush blocks until all messages queued before the call have been forwarded
 // over the tunnel. It must be called before the process exits (and before
 // s.ctx is cancelled) to guarantee the final log lines are delivered.
@@ -102,14 +86,6 @@ func (s *tunnelLogger) Flush() {
 	case <-ack:
 	case <-s.ctx.Done():
 	}
-}
-
-// enqueue formats and queues a message for the worker to forward.
-func (s *tunnelLogger) enqueue(level tunnel.LogLevel, message string) {
-	s.logChan <- logEntry{msg: &tunnel.LogMessage{
-		LogLevel: level,
-		Message:  s.formatMessage(message),
-	}}
 }
 
 // formatMessage appends structured fields to the message.
@@ -337,4 +313,28 @@ func (s *tunnelLogger) WithFields(fields logrus.Fields) log.Logger {
 
 func (*tunnelLogger) LogrLogSink() logr.LogSink {
 	return nil
+}
+
+// enqueue formats and queues a message for the worker to forward.
+func (s *tunnelLogger) enqueue(level tunnel.LogLevel, message string) {
+	s.logChan <- logEntry{msg: &tunnel.LogMessage{
+		LogLevel: level,
+		Message:  s.formatMessage(message),
+	}}
+}
+
+// handle forwards a single message over the tunnel, or acknowledges a flush
+// request. Sends use a context detached from s.ctx's cancellation so that
+// queued messages can still be delivered during shutdown as long as the
+// underlying connection is alive.
+func (s *tunnelLogger) handle(entry logEntry) {
+	if entry.flush != nil {
+		close(entry.flush)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), 5*time.Second)
+	_, _ = s.client.Log(ctx, entry.msg)
+	// ignore error since we can't use the logger itself
+	cancel()
 }

--- a/pkg/agent/tunnelserver/logger.go
+++ b/pkg/agent/tunnelserver/logger.go
@@ -83,22 +83,34 @@ func (s *tunnelLogger) worker() {
 	}
 }
 
+// flushTimeout caps the entire drain. handle() applies a per-message timeout,
+// so without an overall bound a backlog on a stalled tunnel could block
+// shutdown for buffer-size × per-message timeout. The cap is generous so a
+// healthy drain of a full backlog always completes.
+const flushTimeout = 30 * time.Second
+
 // Flush blocks until all messages queued before the call have been forwarded
-// over the tunnel, or until the worker has stopped. It gates on worker
-// completion rather than s.ctx so it stays a real barrier even when s.ctx is
-// already cancelled (e.g. the deferred flush on the shutdown path, or
-// Fatal/Fatalf).
+// over the tunnel, until the worker has stopped, or until flushTimeout elapses.
+// It gates on worker completion rather than s.ctx so it stays a real barrier
+// even when s.ctx is already cancelled (e.g. the deferred flush on the shutdown
+// path, or Fatal/Fatalf).
 func (s *tunnelLogger) Flush() {
 	ack := make(chan struct{})
+	timer := time.NewTimer(flushTimeout)
+	defer timer.Stop()
+
 	select {
 	case s.logChan <- logEntry{flush: ack}:
 	case <-s.done:
+		return
+	case <-timer.C:
 		return
 	}
 
 	select {
 	case <-ack:
 	case <-s.done:
+	case <-timer.C:
 	}
 }
 

--- a/pkg/agent/tunnelserver/logger.go
+++ b/pkg/agent/tunnelserver/logger.go
@@ -27,7 +27,7 @@ func NewTunnelLogger(ctx context.Context, client tunnel.TunnelClient, debug bool
 		ctx:     ctx,
 		client:  client,
 		level:   level,
-		logChan: make(chan *tunnel.LogMessage, 1000), // Buffer size of 1000 messages
+		logChan: make(chan logEntry, 1000), // Buffer size of 1000 messages
 	}
 
 	go logger.worker()
@@ -35,26 +35,81 @@ func NewTunnelLogger(ctx context.Context, client tunnel.TunnelClient, debug bool
 	return logger
 }
 
+// logEntry is what flows through the logger channel. It is either a log
+// message to forward over the tunnel, or a flush request whose ack channel is
+// closed once all preceding messages have been sent.
+type logEntry struct {
+	msg   *tunnel.LogMessage
+	flush chan struct{}
+}
+
 type tunnelLogger struct {
 	ctx     context.Context
 	level   logrus.Level
 	client  tunnel.TunnelClient
-	logChan chan *tunnel.LogMessage
+	logChan chan logEntry
 	fields  logrus.Fields
 }
 
 func (s *tunnelLogger) worker() {
 	for {
 		select {
-		case msg := <-s.logChan:
-			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-			_, _ = s.client.Log(ctx, msg)
-			// ignore error since we can't use the logger itself
-			cancel()
+		case entry := <-s.logChan:
+			s.handle(entry)
 		case <-s.ctx.Done():
-			return
+			// Best-effort drain so the final lines aren't lost when the
+			// agent shuts down before the channel has been emptied.
+			for {
+				select {
+				case entry := <-s.logChan:
+					s.handle(entry)
+				default:
+					return
+				}
+			}
 		}
 	}
+}
+
+// handle forwards a single message over the tunnel, or acknowledges a flush
+// request. Sends use a context detached from s.ctx's cancellation so that
+// queued messages can still be delivered during shutdown as long as the
+// underlying connection is alive.
+func (s *tunnelLogger) handle(entry logEntry) {
+	if entry.flush != nil {
+		close(entry.flush)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), 5*time.Second)
+	_, _ = s.client.Log(ctx, entry.msg)
+	// ignore error since we can't use the logger itself
+	cancel()
+}
+
+// Flush blocks until all messages queued before the call have been forwarded
+// over the tunnel. It must be called before the process exits (and before
+// s.ctx is cancelled) to guarantee the final log lines are delivered.
+func (s *tunnelLogger) Flush() {
+	ack := make(chan struct{})
+	select {
+	case s.logChan <- logEntry{flush: ack}:
+	case <-s.ctx.Done():
+		return
+	}
+
+	select {
+	case <-ack:
+	case <-s.ctx.Done():
+	}
+}
+
+// enqueue formats and queues a message for the worker to forward.
+func (s *tunnelLogger) enqueue(level tunnel.LogLevel, message string) {
+	s.logChan <- logEntry{msg: &tunnel.LogMessage{
+		LogLevel: level,
+		Message:  s.formatMessage(message),
+	}}
 }
 
 // formatMessage appends structured fields to the message.
@@ -75,10 +130,7 @@ func (s *tunnelLogger) Debug(args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_DEBUG,
-		Message:  s.formatMessage(fmt.Sprintln(args...)),
-	}
+	s.enqueue(tunnel.LogLevel_DEBUG, fmt.Sprintln(args...))
 }
 
 func (s *tunnelLogger) Debugf(format string, args ...any) {
@@ -86,10 +138,7 @@ func (s *tunnelLogger) Debugf(format string, args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_DEBUG,
-		Message:  s.formatMessage(fmt.Sprintf(format, args...) + "\n"),
-	}
+	s.enqueue(tunnel.LogLevel_DEBUG, fmt.Sprintf(format, args...)+"\n")
 }
 
 func (s *tunnelLogger) Info(args ...any) {
@@ -97,10 +146,7 @@ func (s *tunnelLogger) Info(args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_INFO,
-		Message:  s.formatMessage(fmt.Sprintln(args...)),
-	}
+	s.enqueue(tunnel.LogLevel_INFO, fmt.Sprintln(args...))
 }
 
 func (s *tunnelLogger) Infof(format string, args ...any) {
@@ -108,10 +154,7 @@ func (s *tunnelLogger) Infof(format string, args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_INFO,
-		Message:  s.formatMessage(fmt.Sprintf(format, args...) + "\n"),
-	}
+	s.enqueue(tunnel.LogLevel_INFO, fmt.Sprintf(format, args...)+"\n")
 }
 
 func (s *tunnelLogger) Warn(args ...any) {
@@ -119,10 +162,7 @@ func (s *tunnelLogger) Warn(args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_WARNING,
-		Message:  s.formatMessage(fmt.Sprintln(args...)),
-	}
+	s.enqueue(tunnel.LogLevel_WARNING, fmt.Sprintln(args...))
 }
 
 func (s *tunnelLogger) Warnf(format string, args ...any) {
@@ -130,10 +170,7 @@ func (s *tunnelLogger) Warnf(format string, args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_WARNING,
-		Message:  s.formatMessage(fmt.Sprintf(format, args...) + "\n"),
-	}
+	s.enqueue(tunnel.LogLevel_WARNING, fmt.Sprintf(format, args...)+"\n")
 }
 
 func (s *tunnelLogger) Error(args ...any) {
@@ -141,10 +178,7 @@ func (s *tunnelLogger) Error(args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_ERROR,
-		Message:  s.formatMessage(fmt.Sprintln(args...)),
-	}
+	s.enqueue(tunnel.LogLevel_ERROR, fmt.Sprintln(args...))
 }
 
 func (s *tunnelLogger) Errorf(format string, args ...any) {
@@ -152,10 +186,7 @@ func (s *tunnelLogger) Errorf(format string, args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_ERROR,
-		Message:  s.formatMessage(fmt.Sprintf(format, args...) + "\n"),
-	}
+	s.enqueue(tunnel.LogLevel_ERROR, fmt.Sprintf(format, args...)+"\n")
 }
 
 func (s *tunnelLogger) Fatal(args ...any) {
@@ -163,11 +194,10 @@ func (s *tunnelLogger) Fatal(args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_ERROR,
-		Message:  s.formatMessage(fmt.Sprintln(args...)),
-	}
+	s.enqueue(tunnel.LogLevel_ERROR, fmt.Sprintln(args...))
 
+	// make sure the message is delivered before we exit
+	s.Flush()
 	os.Exit(1)
 }
 
@@ -176,11 +206,10 @@ func (s *tunnelLogger) Fatalf(format string, args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_ERROR,
-		Message:  s.formatMessage(fmt.Sprintf(format, args...) + "\n"),
-	}
+	s.enqueue(tunnel.LogLevel_ERROR, fmt.Sprintf(format, args...)+"\n")
 
+	// make sure the message is delivered before we exit
+	s.Flush()
 	os.Exit(1)
 }
 
@@ -189,10 +218,7 @@ func (s *tunnelLogger) Done(args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_DONE,
-		Message:  s.formatMessage(fmt.Sprintln(args...)),
-	}
+	s.enqueue(tunnel.LogLevel_DONE, fmt.Sprintln(args...))
 }
 
 func (s *tunnelLogger) Donef(format string, args ...any) {
@@ -200,10 +226,7 @@ func (s *tunnelLogger) Donef(format string, args ...any) {
 		return
 	}
 
-	s.logChan <- &tunnel.LogMessage{
-		LogLevel: tunnel.LogLevel_DONE,
-		Message:  s.formatMessage(fmt.Sprintf(format, args...) + "\n"),
-	}
+	s.enqueue(tunnel.LogLevel_DONE, fmt.Sprintf(format, args...)+"\n")
 }
 
 func (s *tunnelLogger) Print(level logrus.Level, args ...any) {


### PR DESCRIPTION
Fixes #763

## Problem

The last stdout/stderr line of a lifecycle hook (e.g. a failing `postStartCommand.sh`) is missing from the `devpod up` output.

The agent-side `tunnelLogger` forwards log lines over the tunnel asynchronously via a background worker goroutine. On shutdown — such as when a lifecycle hook exits non-zero — the agent process returns the error and the context is cancelled before the worker drains the channel, so the last queued line(s) are silently dropped (`_, _ = s.client.Log(...)`).

## Reproduce

```
devpod up github.com/terenho-jobber/vscode-remote-try-python@test-devpod-stderr
```

The `test-devpod-stderr` branch has a `postStartCommand.sh` that prints two stdout/stderr lines, sleeps, prints two more, then `exit 10`:

```bash
echo "TEST STDOUT MESSAGE"
echo "TEST STDERR MESSAGE" >&2
sleep 20
echo "TEST STDOUT MESSAGE then exit immediately"
echo "TEST STDERR MESSAGE then exit immediately" >&2   # <-- last line, dropped
exit 10
```

**Actual (before fix):** the final stderr line `TEST STDERR MESSAGE then exit immediately` never appears — the output jumps from the stdout line straight to the `exit status 10` failure:

```
info  running postStartCommands lifecycle hook:  /bin/bash .devcontainer/postStartCommand.sh
warn  TEST STDERR MESSAGE
info  TEST STDOUT MESSAGE
info  TEST STDOUT MESSAGE then exit immediately
error Try using the --debug flag to see a more verbose output
fatal run agent command failed: exit status 1: Process exited with status 1
lifecycle hooks: failed to run: /bin/bash .devcontainer/postStartCommand.sh, error: exit status 10
```

**Expected (after fix):** the final stderr line is forwarded before teardown:

```
info  running postStartCommands lifecycle hook:  /bin/bash .devcontainer/postStartCommand.sh
warn  TEST STDERR MESSAGE
info  TEST STDOUT MESSAGE
info  TEST STDOUT MESSAGE then exit immediately
warn  TEST STDERR MESSAGE then exit immediately
error Try using the --debug flag to see a more verbose output
fatal run agent command failed: exit status 1: Process exited with status 1
lifecycle hooks: failed to run: /bin/bash .devcontainer/postStartCommand.sh, error: exit status 10
```

(The `exit status 10` failure itself is expected — the branch exists solely to demonstrate the dropped last line.)

## Fix

- Add a `Flush()` method that drains the channel and blocks until queued messages are sent.
- Defer `logger.Flush()` in the container setup `Run` path (runs while `ctx` is still alive, before teardown).
- Send with a cancellation-detached context (`context.WithoutCancel`) so in-flight messages aren't dropped at shutdown.
- Flush before `Fatal`/`Fatalf` call `os.Exit`.
- Route all level methods through a small `enqueue()` helper to cut duplication.

## Test plan

Reproduce against the `test-devpod-stderr` branch with a locally-built CLI and agent.

Because a dev build reports version `v0.0.0`, DevPod injects the agent over stdin via the `BinaryManager`, which checks `${TMPDIR}/devpod-cache/devpod-linux-<arch>` (`FileCacheSource`) before falling back to the GitHub release. Dropping the local build there makes DevPod inject *it* instead of the published binary — no HTTP server or release needed.

```bash
# 1. Build the local CLI
go build -o devpod .

# 2. Build the agent for the container's OS/arch (arm64 shown; use amd64 on Intel/most Linux hosts)
DEST="${TMPDIR:-/tmp}/devpod-cache"
mkdir -p "$DEST"
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$DEST/devpod-linux-arm64" .

# 3. Recreate the workspace so the agent is re-injected and postStartCommand re-fires
./devpod up github.com/terenho-jobber/vscode-remote-try-python@test-devpod-stderr \
  --recreate --ide none
```

- [x] **Before fix:** the final `TEST STDERR MESSAGE then exit immediately` line is missing.
- [x] **After fix:** that line appears (`warn TEST STDERR MESSAGE then exit immediately`) before the `exit status 10` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of log delivery during shutdown so asynchronously forwarded tunnel logs are flushed to the client before connections close, preventing dropped final log lines.

* **Tests**
  * Added an end-to-end test that exercises a failing provider lifecycle hook and verifies queued logs are flushed before teardown.
  * Added a test fixture (devcontainer and script) that reproduces and verifies the flush behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->