### PR TITLE
fix(devcontainer): preserve readonly compose mounts

### DIFF
--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -27,6 +27,7 @@ const (
 	ConfigFilesLabel                = "com.docker.compose.project.config_files"
 	FeaturesBuildOverrideFilePrefix = "docker-compose.devcontainer.build"
 	FeaturesStartOverrideFilePrefix = "docker-compose.devcontainer.containerFeatures"
+	readOnlyMountOption             = "readonly"
 )
 
 type composeProjectFiles struct {
@@ -1126,9 +1127,10 @@ exec "$$@"
 
 	for _, mount := range mergedConfig.Mounts {
 		overrideService.Volumes = append(overrideService.Volumes, composetypes.ServiceVolumeConfig{
-			Type:   mount.Type,
-			Source: mount.Source,
-			Target: mount.Target,
+			Type:     mount.Type,
+			Source:   mount.Source,
+			Target:   mount.Target,
+			ReadOnly: isReadOnlyMount(mount),
 		})
 	}
 
@@ -1156,6 +1158,15 @@ exec "$$@"
 	}
 
 	return project
+}
+
+func isReadOnlyMount(mount *config.Mount) bool {
+	for _, option := range mount.Other {
+		if option == readOnlyMountOption || option == "ro" {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *runner) configureGPUResources(

--- a/pkg/devcontainer/compose_test.go
+++ b/pkg/devcontainer/compose_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/skevetter/devpod/pkg/compose"
 	"github.com/skevetter/devpod/pkg/devcontainer/config"
 	"github.com/skevetter/devpod/pkg/devcontainer/feature"
+	"github.com/skevetter/devpod/pkg/docker"
 	logLib "github.com/skevetter/log"
 	"github.com/stretchr/testify/suite"
 )
+
+const bindMountType = "bind"
 
 type composeBuildImageNameTestCase struct {
 	name          string
@@ -171,6 +174,50 @@ func (s *ComposeSuite) TestCreateComposeServiceUsesBuildImageName() {
 	s.Require().NotNil(service.Build.Args)
 	s.requireBuildArgValue(service.Build.Args, "FEATURE_FLAG", "true")
 	s.requireBuildArgValue(service.Build.Args, "BUILDKIT_INLINE_CACHE", "1")
+}
+
+func (s *ComposeSuite) TestGenerateDockerComposeUpProjectPreservesReadOnlyMountOptions() {
+	r := &runner{}
+
+	project := r.generateDockerComposeUpProject(
+		&config.SubstitutedConfig{Config: &config.DevContainerConfig{}},
+		&config.MergedDevContainerConfig{
+			NonComposeBase: config.NonComposeBase{
+				Mounts: []*config.Mount{
+					{
+						Type:   bindMountType,
+						Source: "/tmp/read-only-data",
+						Target: "/workspace/read_only_folder",
+						Other:  []string{readOnlyMountOption},
+					},
+					{
+						Type:   bindMountType,
+						Source: "/tmp/read-only-short-data",
+						Target: "/workspace/read_only_short_folder",
+						Other:  []string{"ro"},
+					},
+					{
+						Type:   bindMountType,
+						Source: "/tmp/valued-read-only-data",
+						Target: "/workspace/valued_read_only_folder",
+						Other:  []string{"readonly=true"},
+					},
+				},
+			},
+		},
+		&compose.ComposeHelper{Docker: &docker.DockerHelper{DockerCommand: "true"}},
+		&composetypes.ServiceConfig{Name: "app"},
+		"mcr.microsoft.com/devcontainers/base:noble",
+		"mcr.microsoft.com/devcontainers/base:noble",
+		&config.ImageDetails{},
+		nil,
+	)
+
+	service := project.Services["app"]
+	s.Require().Len(service.Volumes, 3)
+	s.True(service.Volumes[0].ReadOnly)
+	s.True(service.Volumes[1].ReadOnly)
+	s.False(service.Volumes[2].ReadOnly)
 }
 
 func (s *ComposeSuite) requireBuildArgValue(


### PR DESCRIPTION
## Summary

- Preserve `readonly` and `ro` mount options when devcontainer mounts are converted into generated Docker Compose service volumes.
- Add coverage for compose-mode mount conversion so `readonly` and `ro` become read-only volumes while valued options like `readonly=true` remain unsupported.

## Root Cause

`config.Mount` stores mount options that are not modeled directly in `Other`. The non-compose Docker path serializes those options back into the mount string, but the compose override path rebuilt `ServiceVolumeConfig` with only `Type`, `Source`, and `Target`, dropping `readonly`/`ro` before Docker Compose saw them.

## Validation

- `go test ./pkg/devcontainer/...`

Fixes #766.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker Compose configuration generation to preserve read-only mount intent. Mounts specified as `readonly`, `ro`, or `readonly=true` are now correctly marked as read-only in the generated service volumes.

* **Tests**
  * Added coverage validating that read-only mount options are retained across multiple formats and generate the expected volume `ReadOnly` settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->